### PR TITLE
feat: auto assign and remove unassigned for new members

### DIFF
--- a/src/events/MemberJoin.ts
+++ b/src/events/MemberJoin.ts
@@ -8,6 +8,9 @@ class MemberJoin {
     bot: Discord.Client;
 
     constructor(member: GuildMember | PartialGuildMember) {
+        const unassignedRole = member.guild.roles.cache.find(role => role.name === "Unassigned");
+        member.roles.add(unassignedRole);
+
         if(member.roles.cache.find(r => r.name === "Buddy Project 2020")) {
             BuddyProjectSignup(member);
         }

--- a/src/programs/WhereAreYouFromManager.ts
+++ b/src/programs/WhereAreYouFromManager.ts
@@ -50,6 +50,8 @@ export default async function WhereAreYouFromManager(pMessage: Discord.Message) 
                 return;
             }
             pMessage.member.roles.add(roleToAssign);
+            const unassignedRole = pMessage.member.guild.roles.cache.find(role => role.name === "Unassigned");
+            pMessage.member.roles.remove(unassignedRole);
             pMessage.react("👍")
             pMessage.member.createDM().then(dmChannel => {
                 const rules = pMessage.guild.channels.cache.find(c => c.name === "rules");


### PR DESCRIPTION
Potential quick win:

New users get unassigned on join and have it removed when they receive a country role from the bot.
Especially with a lot of new users coming in, it's probably a good idea to have some automated way of doing this.

Potential alternative: Scratch Unassigned all together and use `@everyone` in flag-drop?

Opening this as draft before it's merged and then not needed. I am going to open or close once results on the above question are in!