### PR TITLE
Fix/buddy project stuff

### DIFF
--- a/src/events/GuildMemberUpdate.ts
+++ b/src/events/GuildMemberUpdate.ts
@@ -17,20 +17,6 @@ class GuildMemberUpdate {
     oldMember: GuildMember | PartialGuildMember,
     newMember: GuildMember | PartialGuildMember
   ) {
-    if (
-      hasRole(newMember, "Buddy Project 2020") &&
-      !hasRole(oldMember, "Buddy Project 2020")
-    ) {
-      BuddyProjectSignup(newMember as GuildMember).then((output) => {
-        const buddyProjectOutputChannel = <TextChannel>(
-          oldMember.guild.channels.cache.find(
-            (c) => c.name === "buddy-project-output"
-          )
-        );
-        buddyProjectOutputChannel.send(output);
-      });
-    }
-
     const regionCountries = ["Australia", "Canada", "the UK", "the USA"];
     const findGeneralRole = (member: GuildMember | PartialGuildMember) =>
       member.roles.cache.find(({ name }) => {

--- a/src/events/ReactionAdd.ts
+++ b/src/events/ReactionAdd.ts
@@ -87,7 +87,6 @@ class ReactionAdd {
       outputChannel.send(
         `<@${this.user}> is signing up again for the relaunch.`
       );
-      outputChannel.send(await removeEntry(this.user));
       outputChannel.send(
         await BuddyProjectSignup(this.guild.member(this.user))
       );

--- a/src/events/ReactionAdd.ts
+++ b/src/events/ReactionAdd.ts
@@ -74,13 +74,6 @@ class ReactionAdd {
       this.pureEmoji === "🤓" &&
       !this.user.bot
     ) {
-      this.user
-        .createDM()
-        .then((dmChannel) =>
-          dmChannel.send(
-            "Thanks for signing up to the relaunch! This will work the same as last time, except this time you are guaranteed to get a new member."
-          )
-        );
       let outputChannel = <TextChannel>(
         this.guild.channels.cache.find((c) => c.name === "buddy-project-output")
       );

--- a/src/programs/BuddyProject.ts
+++ b/src/programs/BuddyProject.ts
@@ -71,7 +71,7 @@ export async function BuddyProjectSignup(member: GuildMember): Promise<string> {
   const dmChannel = await member.createDM();
   const buddyEntries = await BuddyProjectEntryRepository();
   let memberEntry = await buddyEntries.findOne(member.id);
-  let output = `New entry from ${member.toString()}`;
+  let output = `New attempted entry from ${member.toString()}`;
   const addOutput = (arg: string) => (output = output.concat(`\n${arg}`));
 
   if (memberEntry) {

--- a/src/programs/BuddyProject.ts
+++ b/src/programs/BuddyProject.ts
@@ -97,14 +97,16 @@ export async function BuddyProjectSignup(member: GuildMember): Promise<string> {
   });
   await buddyEntries.save(memberEntry);
 
-  const bpRole = member.guild.roles.cache.find(r => r.name === "Buddy Project 2020");
-  if (member.roles.cache.find(r => r.id === bpRole.id))
+  const bpRole = member.guild.roles.cache.find(
+    (r) => r.name === "Buddy Project 2020"
+  );
+  if (member.roles.cache.find((r) => r.id === bpRole.id))
     member.roles.add(bpRole);
 
   const successMessage = discord_user
     ? "Woo! You just signed up to the buddy project, exciting right? I'll message you again momentarily with your buddy and what you need to do next!"
     : "Thanks for signing up to the relaunch! This will work the same as last time, except this time you are guaranteed to get a new member.";
-    
+
   dmChannel.send(successMessage);
   addOutput("Successfully entered.");
 
@@ -187,7 +189,7 @@ export const buddyProjectMatch = async (
   force: boolean = false
 ): Promise<Boolean> => {
   const buddyEntries = await BuddyProjectEntryRepository();
-  
+
   const hasBuddy1 = (await buddyEntries.findOne(user1.id)).matched;
   if (hasBuddy1 && !force) return false;
   const hasBuddy2 = (await buddyEntries.findOne(user2.id)).matched;

--- a/src/programs/BuddyProject.ts
+++ b/src/programs/BuddyProject.ts
@@ -97,6 +97,10 @@ export async function BuddyProjectSignup(member: GuildMember): Promise<string> {
   });
   await buddyEntries.save(memberEntry);
 
+  const bpRole = member.guild.roles.cache.find(r => r.name === "Buddy Project 2020");
+  if (member.roles.cache.find(r => r.id === bpRole.id))
+    member.roles.add(bpRole);
+
   const successMessage =
     "Woo! You just signed up to the buddy project, exciting right? I'll message you again momentarily with your buddy and what you need to do next!";
   dmChannel.send(successMessage);

--- a/src/programs/BuddyProject.ts
+++ b/src/programs/BuddyProject.ts
@@ -101,8 +101,10 @@ export async function BuddyProjectSignup(member: GuildMember): Promise<string> {
   if (member.roles.cache.find(r => r.id === bpRole.id))
     member.roles.add(bpRole);
 
-  const successMessage =
-    "Woo! You just signed up to the buddy project, exciting right? I'll message you again momentarily with your buddy and what you need to do next!";
+  const successMessage = discord_user
+    ? "Woo! You just signed up to the buddy project, exciting right? I'll message you again momentarily with your buddy and what you need to do next!"
+    : "Thanks for signing up to the relaunch! This will work the same as last time, except this time you are guaranteed to get a new member.";
+    
   dmChannel.send(successMessage);
   addOutput("Successfully entered.");
 

--- a/src/programs/BuddyProject.ts
+++ b/src/programs/BuddyProject.ts
@@ -177,9 +177,16 @@ export const sendQuestions = (
 
 export const buddyProjectMatch = async (
   user1: GuildMember | User,
-  user2: GuildMember | User
+  user2: GuildMember | User,
+  force: boolean = false
 ): Promise<Boolean> => {
   const buddyEntries = await BuddyProjectEntryRepository();
+  
+  const hasBuddy1 = (await buddyEntries.findOne(user1.id)).matched;
+  if (hasBuddy1 && !force) return false;
+  const hasBuddy2 = (await buddyEntries.findOne(user2.id)).matched;
+  if (hasBuddy2 && !force) return false;
+
   const user1Entry = buddyEntries.create({
     user_id: user1.id,
     matched: true,

--- a/src/programs/BuddyProjectManager.ts
+++ b/src/programs/BuddyProjectManager.ts
@@ -24,11 +24,13 @@ export default async function BuddyProjectManager(
             ? `Sent messages.`
             : `Couldn't send messages.`
         );
-        buddyProjectMatch(usersToMatch[0], usersToMatch[1], true).then((result) => {
-          message.channel.send(
-            result ? `Successfully matched.` : `Error in setting match.`
-          );
-        });
+        buddyProjectMatch(usersToMatch[0], usersToMatch[1], true).then(
+          (result) => {
+            message.channel.send(
+              result ? `Successfully matched.` : `Error in setting match.`
+            );
+          }
+        );
       }
       break;
     case "check":

--- a/src/programs/BuddyProjectManager.ts
+++ b/src/programs/BuddyProjectManager.ts
@@ -24,7 +24,7 @@ export default async function BuddyProjectManager(
             ? `Sent messages.`
             : `Couldn't send messages.`
         );
-        buddyProjectMatch(usersToMatch[0], usersToMatch[1]).then((result) => {
+        buddyProjectMatch(usersToMatch[0], usersToMatch[1], true).then((result) => {
           message.channel.send(
             result ? `Successfully matched.` : `Error in setting match.`
           );


### PR DESCRIPTION
Fixes a few things in the buddy project (in no particular order):
 - Removing the entry on signup leads to absolutely no checks whatsoever whether the user doing it was already matched allowing users to spam the signup reaction to get new buddies with the sideeffect of removing the people they matched with from the database.
 - Because the signup isn't coupled to the Buddy Project 2020 role anymore, the trigger on gaining the role was removed. Also everyone who signed up will get the role assigned by the bot now.
 - Tiny tweak to the output message because it was weird to read "New entry" eventhough I had already entered so it was technically not a new entry.
 - "Thanks for signing up to the relaunch [...]" was sent when clicking the signup reaction no matter whether you were already signed up, matched, etc *and* followed by "Woo! You just signed up [...]" in case of successful registration. I picked up Léa's suggestion and reused the message as alternative to the "Woo! [...]" one for Discord users.
 - Obligatory prettier :')