### PR TITLE
fix: Override for Argentina Timezones

### DIFF
--- a/src/programs/BirthdayManager.ts
+++ b/src/programs/BirthdayManager.ts
@@ -415,6 +415,9 @@ function timezonesFromRole(props: CountryWithRegion): readonly string[] {
         "America/Sao_Paulo",
       ];
     }
+    case "Argentina": {
+      return ["America/Buenos_Aires"];
+    }
     case "the UAE": {
       return getCountry("AE").timezones;
     }


### PR DESCRIPTION
Argentina has a lot of listed timezones, only one of which seems relevant however. Added override for that because some of the list broke the bot.