### PR TITLE
fix: broken group ping when used immediately after a linebreak

### DIFF
--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -57,7 +57,7 @@ class MessageManager {
   routeMessage() {
     const filteredWords = ["nigger", "nigga"];
 
-    const words = this.message.content.split(" ");
+    const words = this.message.content.split(/\s+/);
     const firstWord = words[0];
     const channel = <Discord.TextChannel>this.message.channel;
 


### PR DESCRIPTION
Because messages were only split on spaces, using a group ping immediately after a linebreak would leave the entry in the words array as `something\n@group`.

This PR changes splitting to whitespace in general.