### PR TITLE
chore: remove irrelevant logging

### DIFF
--- a/src/programs/GroupManager.ts
+++ b/src/programs/GroupManager.ts
@@ -359,10 +359,7 @@ const searchGroup = async (
       if (first.emoji.name === "➡️") {
         flip(currentPage + 1, pagedMessage, first);
       }
-    } catch (error) {
-      if (error !== "time") console.log(JSON.stringify(error));
-      else console.log("Knew it...");
-    }
+    } catch (error) {}
   };
 
   const sentMessagePromise = message.channel.send(

--- a/src/programs/Someone.ts
+++ b/src/programs/Someone.ts
@@ -76,7 +76,6 @@ async function updateLastMessage(message: Discord.Message) {
   });
 
   try {
-    console.info("@someone: Updating database record");
     someones.save({
       ...someone,
       time: new Date(),


### PR DESCRIPTION
This PR removes logging in two positions that are frequently hit and serve no purpose anymore. Thus the only thing the logs are doing are clutter the output of journalctl and can be removed.