### PR TITLE
Allow Supports selection of Nitro colors

### DIFF
--- a/src/events/GuildMemberUpdate.ts
+++ b/src/events/GuildMemberUpdate.ts
@@ -9,7 +9,7 @@ import {
 } from "discord.js";
 import Tools from "../common/tools";
 import { hasRole } from "../common/moderator";
-import { Separators } from "../programs";
+import { Separators, NitroColors } from "../programs";
 
 class GuildMemberUpdate {
   bot: Client;
@@ -42,24 +42,8 @@ class GuildMemberUpdate {
     if (hasRole(oldMember, "Time Out") && !hasRole(newMember, "Time Out")) {
       resolvePerUserPermissions(newMember);
     }
-    const nitroRoles = [
-      "636670666447388702",
-      "636525712450256896",
-      "636902084108615690",
-      "636483478640132106",
-      "636901944790876160",
-    ];
-    const nitroColor: Role = newMember.roles.cache.find((r) =>
-      nitroRoles.includes(r.id)
-    );
-    if (
-      nitroColor &&
-      !hasRole(newMember, "Nitro Booster") &&
-      !hasRole(newMember, "Support")
-    ) {
-      newMember.roles.remove(nitroColor);
-    }
 
+    NitroColors.removeColorIfNotAllowed(newMember);
     Separators.seperatorOnRoleAdd(oldMember, newMember);
     Separators.seperatorOnRoleRemove(oldMember, newMember);
   }

--- a/src/events/ReactionAdd.ts
+++ b/src/events/ReactionAdd.ts
@@ -15,6 +15,7 @@ import {
   BuddyProject,
   BuddyProjectGhost,
   GroupManagerTools,
+  NitroColors,
 } from "../programs";
 import { MessageRepository, ReactionRoleRepository } from "../entities";
 import { hasRole } from "../common/moderator";
@@ -100,8 +101,8 @@ class ReactionAdd {
       );
 
       if (
-        this.hasNitroColour(guildMember) &&
-        this.messageId == "637401981262102578"
+        NitroColors.isColorSelectionMessage(this.messageId) &&
+        NitroColors.memberHasNitroColor(guildMember)
       ) {
         guildMember
           .createDM()
@@ -110,6 +111,8 @@ class ReactionAdd {
               "You can't assign yourself a new colour yet, please wait until the end of the month!"
             )
           );
+
+        this.messageReaction.users.remove(guildMember);
       } else {
         guildMember.roles.add(roleToAdd);
       }
@@ -117,23 +120,6 @@ class ReactionAdd {
 
     this.handleChannelToggleReaction();
   }
-
-  hasNitroColour = (member: GuildMember): boolean => {
-    const nitroColours: string[] = [
-      "636122019183722496",
-      "636902084108615690",
-      "636901944790876160",
-      "636525712450256896",
-      "636670666447388702",
-    ];
-    let hasColour = false;
-    nitroColours.forEach((colour) => {
-      if (member.roles.cache.find((role) => role.id === colour)) {
-        hasColour = true;
-      }
-    });
-    return hasColour;
-  };
 
   async handleChannelToggleReaction() {
     const messageRepository = await MessageRepository();

--- a/src/events/Ready.ts
+++ b/src/events/Ready.ts
@@ -1,6 +1,6 @@
 import Discord from "discord.js";
 import { GUILD_ID, OUTPUT_CHANNEL_ID } from "../const";
-import { VoiceOnDemandTools } from "../programs";
+import { VoiceOnDemandTools, NitroColors } from "../programs";
 
 class Ready {
   bot: Discord.Client;
@@ -16,6 +16,7 @@ class Ready {
       outputChannel.send(`${bot.user.tag} - Online`);
     }
 
+    NitroColors.cacheNitroColors(GUILD_ID);
     VoiceOnDemandTools.voiceOnDemandReady(bot);
   }
 }

--- a/src/programs/NitroColors.ts
+++ b/src/programs/NitroColors.ts
@@ -31,7 +31,7 @@ export const removeColorIfNotAllowed = async (
   member: GuildMember | PartialGuildMember
 ) => {
   // At least one is required for a nitro color
-  const roleRequirements = ["Nitro Booster"];
+  const roleRequirements = ["Nitro Booster", "Support"];
 
   const nitroColor: Role = member.roles.cache.find((r) =>
     nitroRolesCache.some((role) => role.id === r.id)

--- a/src/programs/NitroColors.ts
+++ b/src/programs/NitroColors.ts
@@ -1,0 +1,53 @@
+import bot from "../index";
+import {
+  Snowflake,
+  TextChannel,
+  Role,
+  Collection,
+  GuildMember,
+  PartialGuildMember,
+  Message,
+} from "discord.js";
+import { hasRole } from "../common/moderator";
+
+let nitroRolesCache: Collection<Snowflake, Role>;
+let colorSelectionMessage: Message;
+
+export const cacheNitroColors = async (guildId: Snowflake) => {
+  const pickYourColorChannel = bot.guilds
+    .resolve(guildId)
+    .channels.cache.find(
+      (channel) => channel.name === "pick-your-color"
+    ) as TextChannel;
+
+  colorSelectionMessage = await pickYourColorChannel.messages
+    .fetch({ limit: 1 })
+    .then((messages) => messages.first());
+
+  nitroRolesCache = colorSelectionMessage.mentions.roles;
+};
+
+export const removeColorIfNotAllowed = async (
+  member: GuildMember | PartialGuildMember
+) => {
+  // At least one is required for a nitro color
+  const roleRequirements = ["Nitro Booster"];
+
+  const nitroColor: Role = member.roles.cache.find((r) =>
+    nitroRolesCache.some((role) => role.id === r.id)
+  );
+
+  const isColorAllowed = roleRequirements.some((role) => hasRole(member, role));
+
+  if (nitroColor && !isColorAllowed) {
+    member.roles.remove(nitroColor);
+  }
+};
+
+export const memberHasNitroColor = (member: GuildMember) =>
+  member.roles.cache.some((role) =>
+    nitroRolesCache.some((r) => r.id === role.id)
+  );
+
+export const isColorSelectionMessage = (messageId: Snowflake) =>
+  colorSelectionMessage.id === messageId;

--- a/src/programs/ReactRole.ts
+++ b/src/programs/ReactRole.ts
@@ -14,7 +14,7 @@ export default async function ReactRole(message: Discord.Message) {
 
   if (!action || !["add", "list", "delete", "search"].includes(action)) {
     message.reply(
-      `Incorrect syntax, please use the following: \`!roles add|list|delete\``
+      `Incorrect syntax, please use the following: \`!role add|list|delete\``
     );
     return;
   }
@@ -22,7 +22,7 @@ export default async function ReactRole(message: Discord.Message) {
     case "add":
       if (!messageId || !reaction || !roleId || !message) {
         message.reply(
-          `Incorrect syntax, please use the following: \`!roles add messageId reaction roleId <channelId>\``
+          `Incorrect syntax, please use the following: \`!role add messageId reaction roleId <channelId>\``
         );
         return;
       }

--- a/src/programs/index.ts
+++ b/src/programs/index.ts
@@ -11,6 +11,7 @@ import EasterEvent from "./EasterEvent";
 import ExportManager from "./ExportManager";
 import GroupManager from "./GroupManager";
 import InitialiseTestEnvironment from "./InitialiseTestEnvironment";
+import * as NitroColors from "./NitroColors";
 import PollsManager from "./PollsManager";
 import ProfileManager from "./ProfileManager";
 import ReactRole from "./ReactRole";
@@ -37,6 +38,7 @@ export {
   GroupManager,
   GroupManagerTools,
   InitialiseTestEnvironment,
+  NitroColors,
   PollsManager,
   ProfileManager,
   ReactRole,


### PR DESCRIPTION
This PR aimed to allow supports selection of a nitro color. To make testing possible without changing a bunch of hardcoded IDs in several places, the logic handling nitro color selection was first refactored to determine the entities defined by the hardcoded IDs more dynamically.

The message that people can select their color from is not defined by an ID anymore but instead as the first message in the pick-your-color channel.

The nitro roles are not defined by IDs anymore but as any role mentioned in the first message in the pick-your-color channel.

- chore: refactor nitro color handling
- feat: allow supports selection of a nitro color
