### PR TITLE
Feat/voice chat transfer

### DIFF
--- a/src/entities/VoiceOnDemandMapping.ts
+++ b/src/entities/VoiceOnDemandMapping.ts
@@ -7,6 +7,9 @@ export class VoiceOnDemandMapping {
 
   @Column({ name: "channel_id" })
   channelId: string;
+
+  @Column()
+  emoji: string;
 }
 
 export const VoiceOnDemandRepository = async () => {

--- a/src/programs/VoiceOnDemand.ts
+++ b/src/programs/VoiceOnDemand.ts
@@ -182,7 +182,15 @@ export const voiceOnDemandPermissions = async (
 
   const { guild } = channel;
 
+  const timeoutRole = guild.roles.cache.find(
+    (role) => role.name.toLowerCase() === "time out"
+  );
+
   channel.overwritePermissions([
+    {
+      id: timeoutRole.id,
+      deny: [Permissions.FLAGS.CONNECT],
+    },
     {
       id: guild.roles.everyone,
       allow: [Permissions.FLAGS.STREAM],

--- a/src/programs/VoiceOnDemand.ts
+++ b/src/programs/VoiceOnDemand.ts
@@ -131,6 +131,7 @@ const createOnDemand = async (message: Message, userLimit: number) => {
   const mapping = repo.create({
     userId: member.id,
     channelId: channel.id,
+    emoji: reaction.emoji.name,
   });
   await repo.save(mapping);
 
@@ -229,7 +230,7 @@ export const voiceOnDemandReset = async (
 
   if (mapping.userId === newState.member.id) {
     updateTimeout(
-      () => requestOwnershipTransfer(oldState.channel, repo),
+      () => requestOwnershipTransfer(oldState.channel, repo, mapping),
       transferDelay
     );
   }
@@ -280,7 +281,8 @@ const deleteIfEmpty = async (channel: VoiceChannel) => {
 
 const requestOwnershipTransfer = async (
   channel: VoiceChannel,
-  repo: Repository<VoiceOnDemandMapping>
+  repo: Repository<VoiceOnDemandMapping>,
+  mapping: VoiceOnDemandMapping
 ) => {
   if (!channel.guild.channels.resolve(channel.id) || channel.members.size === 0)
     return;
@@ -334,9 +336,7 @@ const requestOwnershipTransfer = async (
     .where("channel_id = :id", { id: channel.id })
     .execute();
 
-  // Little hack but what can you do (aside from properly adding the emoji in the database that is...)
-  const emojiRegex = /• (.*?) /;
-  const emoji = channel.name.match(emojiRegex)[1];
+  const { emoji } = mapping;
   const newChannelName = getChannelName(
     channel.guild.member(claimingUser),
     emoji

--- a/src/programs/VoiceOnDemand.ts
+++ b/src/programs/VoiceOnDemand.ts
@@ -200,10 +200,11 @@ export const voiceOnDemandReset = async (
   // If old and new channel are the same, the channel still has
   //  the same amount of users in so it's not relevant for our purpose
   if (!oldState.channel || oldState.channelID === newState.channelID) return;
+  if (oldState.channel.members.size > 0) return;
 
   const channelId = oldState.channel.id;
   const timeout = state.voiceChannels.get(channelId);
-  clearTimeout(timeout);
+  if (timeout) clearTimeout(timeout);
 
   const repo = await VoiceOnDemandRepository();
 

--- a/src/programs/VoiceOnDemand.ts
+++ b/src/programs/VoiceOnDemand.ts
@@ -40,7 +40,7 @@ export default async function (message: Message) {
   }
 
   const [, command, limitArg = defaultLimit] = message.content.split(" ");
-  const requestedLimit = Number(limitArg);
+  const requestedLimit = Math.floor(Number(limitArg));
 
   if (isNaN(requestedLimit)) {
     Tools.handleUserError(message, "The limit has to be a number");

--- a/src/programs/VoiceOnDemand.ts
+++ b/src/programs/VoiceOnDemand.ts
@@ -37,7 +37,8 @@ const getVoiceChannel = async (member: GuildMember): Promise<VoiceChannel> => {
 
 export default async function (message: Message) {
   if (!hasRole(message.member, "Yes Theory")) {
-    message.reply(
+    Tools.handleUserError(
+      message,
       `Hey, you need to have the Yes Theory role to use this command! You can get this by talking with others in our public voice chats :grin:`
     );
     return;
@@ -52,6 +53,7 @@ export default async function (message: Message) {
       break;
     case "host":
       changeHostOnDemand(message);
+      break;
     default:
       Tools.handleUserError(
         message,


### PR DESCRIPTION
This PR introduces a new feature connected to !voice: Automatic transfer to another user when the original owner leaves.

**Why?**
Imagine someone creates a room, others join, first guy has to leave and the others stick around. Now the limit of the room is stuck to what it is set to because noone else can control it (except for mods which brings us back to the original issue :smile:).

**How?**
When the original owner leaves a timer for one minute is set. If the room isn't empty after a minute, the bot pings all members in the voice channel asking one of them to react with :point_up:. The first person to do so will become the new owner of the room (the name changes and they are able to use !voice limit; emoji stays the same for now). This also allows the original owner to create a new room if they want to as they don't own one anymore.
If noone reacts within a minute, the room is deleted.
