### PR TITLE
fix: error about unkown (deleted) message

### DIFF
--- a/src/programs/Someone.ts
+++ b/src/programs/Someone.ts
@@ -9,7 +9,6 @@ const QUESTION_LINK: string =
   "https://spreadsheets.google.com/feeds/cells/1J7DlkcWzhcm9CXiWCB-dQloCqIHjVpupyvMqBPlJ7Mk/1/public/full?alt=json";
 
 async function Someone(message: Message) {
-  message.delete();
   const allow = await isAllowed(message.author);
 
   if (!allow) {
@@ -52,6 +51,8 @@ async function Someone(message: Message) {
       sendMessage(member, target, question, message.channel as TextChannel);
     }
   }
+
+  message.delete();
 }
 
 const sendMessage = async (


### PR DESCRIPTION
To reproduce the error on master, try using at-someone without the Seek Discomfort role or twice on the same day. In both cases, `Tools#handleUserError` is used to delete the message and display an error message. Deleting the message is already done in the top of the someone code so I moved it down to avoid this.