### PR TITLE
fix: multiple nitrocolor selection

### DIFF
--- a/src/programs/NitroColors.ts
+++ b/src/programs/NitroColors.ts
@@ -21,8 +21,8 @@ export const cacheNitroColors = async (guildId: Snowflake) => {
     ) as TextChannel;
 
   colorSelectionMessage = await pickYourColorChannel.messages
-    .fetch({ limit: 1 })
-    .then((messages) => messages.first());
+    .fetch({ limit: 10 })
+    .then((messages) => messages.array().reverse()[0]);
 
   nitroRolesCache = colorSelectionMessage.mentions.roles;
 };


### PR DESCRIPTION
Because of a second message in the selection channel, one condition required for checking whether someone already has a nitro color was always false because `message.fetch({ limit: 1 });` gets the last message, not the first. This PR fixes this by fetching the last 10 messages, reversing the order and taking the first of those to get the first message of the channel (as long as there is a max of 10 messages in the channel that is).