### PR TITLE
feat/break role

### DIFF
--- a/src/events/GuildMemberUpdate.ts
+++ b/src/events/GuildMemberUpdate.ts
@@ -35,11 +35,17 @@ class GuildMemberUpdate {
       newMember.roles.remove(generalRole);
     }
 
-    if (!hasRole(oldMember, "Time Out") && hasRole(newMember, "Time Out")) {
+    if (
+      gainedRole(oldMember, newMember, "Time Out") ||
+      gainedRole(oldMember, newMember, "Break")
+    ) {
       revokePerUserPermissions(newMember);
     }
 
-    if (hasRole(oldMember, "Time Out") && !hasRole(newMember, "Time Out")) {
+    if (
+      lostRole(oldMember, newMember, "Time Out") ||
+      lostRole(oldMember, newMember, "Break")
+    ) {
       resolvePerUserPermissions(newMember);
     }
 
@@ -48,6 +54,18 @@ class GuildMemberUpdate {
     Separators.seperatorOnRoleRemove(oldMember, newMember);
   }
 }
+
+const gainedRole = (
+  oldMember: GuildMember | PartialGuildMember,
+  newMember: GuildMember | PartialGuildMember,
+  roleName: string
+) => !hasRole(oldMember, roleName) && hasRole(newMember, roleName);
+
+const lostRole = (
+  oldMember: GuildMember | PartialGuildMember,
+  newMember: GuildMember | PartialGuildMember,
+  roleName: string
+) => hasRole(oldMember, roleName) && !hasRole(newMember, roleName);
 
 const revokePerUserPermissions = async (
   newMember: GuildMember | PartialGuildMember

--- a/src/events/GuildMemberUpdate.ts
+++ b/src/events/GuildMemberUpdate.ts
@@ -40,10 +40,7 @@ class GuildMemberUpdate {
       revokePerUserPermissions(newMember);
     }
 
-    if (
-      lostRole(oldMember, newMember, "Time Out") ||
-      lostRole(oldMember, newMember, "Break")
-    ) {
+    if (resolvePerUserCondition(oldMember, newMember)) {
       resolvePerUserPermissions(newMember);
     }
 
@@ -52,6 +49,25 @@ class GuildMemberUpdate {
     Separators.seperatorOnRoleRemove(oldMember, newMember);
   }
 }
+
+// A users per-user permissions shall be restored if they have lost one of the switch roles and every role they have is none of the switchRoles
+const resolvePerUserCondition = (
+  oldMember: GuildMember | PartialGuildMember,
+  newMember: GuildMember | PartialGuildMember
+): boolean => {
+  const switchRoles = ["Time Out", "Break"];
+
+  const lostRevokeRole = switchRoles.some((role) =>
+    lostRole(oldMember, newMember, role)
+  );
+  if (!lostRevokeRole) {
+    return false;
+  }
+
+  return newMember.roles.cache.every(
+    (role) => !switchRoles.includes(role.name)
+  );
+};
 
 const gainedRole = (
   oldMember: GuildMember | PartialGuildMember,

--- a/src/events/GuildMemberUpdate.ts
+++ b/src/events/GuildMemberUpdate.ts
@@ -98,18 +98,21 @@ const resolvePerUserPermissions = async (
   const selectionMessages = selectionChannels.map(
     (channel: TextChannel) => channel.messages.cache.array()[0]
   );
+
   for (let i = 0; i < selectionMessages.length; i++) {
     const reactions = selectionMessages[i].reactions.cache;
-    reactions
-      .filter((reaction) => !!reaction.users.resolve(newMember.id))
-      .forEach((reaction) =>
-        Tools.addPerUserPermissions(
-          reaction.emoji.name,
-          selectionMessages[i].id,
-          newMember.guild,
-          newMember
-        )
+
+    for (const [_, reaction] of reactions) {
+      const users = await reaction.users.fetch();
+      if (!users.has(newMember.id)) continue;
+
+      Tools.addPerUserPermissions(
+        reaction.emoji.name,
+        selectionMessages[i].id,
+        newMember.guild,
+        newMember
       );
+    }
   }
 };
 

--- a/src/programs/VoiceOnDemand.ts
+++ b/src/programs/VoiceOnDemand.ts
@@ -239,19 +239,24 @@ export const voiceOnDemandPermissions = async (
 
   const { guild } = channel;
 
-  const timeoutRole = guild.roles.cache.find(
-    (role) => role.name.toLowerCase() === "time out"
-  );
+  const timeoutRole = Tools.getRoleByName("Time Out", guild);
+  const breakRole = Tools.getRoleByName("Break", guild);
 
   channel.overwritePermissions([
-    {
-      id: timeoutRole.id,
-      deny: [Permissions.FLAGS.CONNECT],
-    },
     {
       id: guild.roles.everyone,
       allow: [Permissions.FLAGS.STREAM],
       deny: [],
+      type: "role",
+    },
+    {
+      id: timeoutRole.id,
+      deny: [Permissions.FLAGS.CONNECT],
+      type: "role",
+    },
+    {
+      id: breakRole.id,
+      deny: [Permissions.FLAGS.VIEW_CHANNEL],
       type: "role",
     },
   ]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    "downlevelIteration": true,               /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -61,7 +61,10 @@
     "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
+    "lib": [
+      "ES2019.Array",
+    ]
   },
   "include": [
     "./index.d.ts",
@@ -70,5 +73,5 @@
   "exclude": [
     "node_modules",
     "build"
-  ]
+  ],
 }


### PR DESCRIPTION
This PR adds support for the upcoming Break role of the server. It's supposed to fully hide all active channels when applied.

Specifically this PR addresses the following things:
 - !voice created channels are locked for Time Out and Break users
 - per-user permissions are properly resolved for all channels when Time Out or Break are removed
 - When given Break, country channels you have view permissions on are locked by per-user permissions