### PR TITLE
fix: full overwrite of permissions when break role is given

### DIFF
--- a/src/events/GuildMemberUpdate.ts
+++ b/src/events/GuildMemberUpdate.ts
@@ -202,13 +202,9 @@ const lockCountryChannels = (member: GuildMember | PartialGuildMember) => {
   getCountryChannels(member.guild)
     .filter(hasReadPermissions)
     .forEach((channel) =>
-      channel.overwritePermissions([
-        {
-          id: member.id,
-          deny: [Permissions.FLAGS.VIEW_CHANNEL],
-          type: "member",
-        },
-      ])
+      channel.updateOverwrite(member.id, {
+        VIEW_CHANNEL: false,
+      })
     );
 };
 


### PR DESCRIPTION
I accidentally set all permissions on the channel instead of overwriting a single one. This PR fixes this to prevent further [invasions of germany](https://cdn.discordapp.com/attachments/450163655452131328/758080174683062312/unknown.png) by just creating a single overwrite instead of resetting everything.