### PR TITLE
fix: non resolving permissions

### DIFF
--- a/src/events/GuildMemberUpdate.ts
+++ b/src/events/GuildMemberUpdate.ts
@@ -145,6 +145,8 @@ const getChannelAccessToggleMessages = async (): Promise<
 const resolvePerUserPermissions = async (
   newMember: GuildMember | PartialGuildMember
 ) => {
+  const after = (BigInt(newMember.id) - BigInt(5)).toString();
+
   const messageToggleList = await getChannelAccessToggleMessages();
   for (const messageId in messageToggleList) {
     const { channelId, toggles } = messageToggleList[messageId];
@@ -158,7 +160,10 @@ const resolvePerUserPermissions = async (
     );
 
     for (const [_, reaction] of relevantReactions) {
-      const users = await reaction.users.fetch();
+      const users = await reaction.users.fetch({
+        after,
+        limit: 10,
+      });
       if (!users.has(newMember.id)) continue;
 
       Tools.addPerUserPermissions(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,6 +64,7 @@
     "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
     "lib": [
       "ES2019.Array",
+      "ES2020.BigInt",
     ]
   },
   "include": [


### PR DESCRIPTION
This is an attempt to fix an issue where reactions are not properly resolved due to API limitations.

Currently to check whether the user has reacted on a certain message with a certain emoji, the message including reactions is fetched, then for each emoji the users are fetched. The API caps this at a limit of 100 users being fetched which isn't enough for the close to 1000 reactions on the most reacted message of the server.

Because the before and after parameters of fetch are connected with *or* and not with *and* using both before and after causes the exact same result.

This PR attempts to use after with a Snowflake close to the one of the users ID (using the new ES2020 BigInts to subtract 5 from their ID). If the IDs that are fetched are sorted ascending, the snowflake fo the user should be in the top 5 results, so we fetch 10 for good measure.

I have honestly no clue if this works but it probably cannot end up more broken than it already is.