### PR TITLE
feat: Unassigned role on entrance, removed on country role

### DIFF
--- a/src/events/MemberJoin.ts
+++ b/src/events/MemberJoin.ts
@@ -4,12 +4,13 @@ import {
   TextChannel,
   PartialGuildMember,
 } from "discord.js";
-import { BuddyProject } from "../programs";
+import { BuddyProject, Unassigned } from "../programs";
 
 class MemberJoin {
   bot: Client;
 
   constructor(member: GuildMember | PartialGuildMember) {
+    Unassigned.UnassignedMemberJoin(member);
     if (member.roles.cache.find((r) => r.name === "Buddy Project 2020")) {
       const bpOutputChannel = <TextChannel>(
         member.guild.channels.cache.find(

--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -21,7 +21,6 @@ import {
   StateRoleFinder,
   Ticket,
   TopicManager,
-  Unassigned,
   VoiceOnDemand,
   WhereAreYouFromManager,
 } from "../programs";
@@ -117,7 +116,6 @@ class MessageManager {
 
       case "permanent-testing":
         if (firstWord === "!export") ExportManager(this.message);
-        if (firstWord === "!unassigned") Unassigned(this.message);
         if (
           firstWord === "!group" &&
           !this.message.content.toLowerCase().startsWith("!group toggle")

--- a/src/programs/Unassigned.ts
+++ b/src/programs/Unassigned.ts
@@ -1,38 +1,18 @@
-import { Message, TextChannel } from "discord.js";
-import { MODERATOR_ROLE_NAME } from "../const";
+import { GuildMember, PartialGuildMember, Guild } from "discord.js";
+import Tools from "../common/tools";
 
-export default function Unassigned(message: Message) {
-  const guild = message.guild;
+const getUnassignedRole = (guild: Guild) =>
+  Tools.getRoleByName("Unassigned", guild);
 
-  const UnassignedRole = guild.roles.cache.find(
-    (role) => role.name === "Unassigned"
-  );
+export const UnassignedMemberJoin = (
+  member: GuildMember | PartialGuildMember
+) => {
+  member.roles.add(getUnassignedRole(member.guild));
+};
 
-  const authorIsSupport = message.guild
-    .member(message.author)
-    .roles.cache.some((role) => role.name === MODERATOR_ROLE_NAME);
-  if (!authorIsSupport) return;
-
-  const isInModSection =
-    (message.channel as TextChannel).name === "permanent-testing";
-  if (!isInModSection) return;
-  const missedUsers = guild.members.cache.filter(
-    (member) => member.roles.cache.size === 1
-  );
-
-  missedUsers.forEach((member) => member.roles.add(UnassignedRole));
-
-  message.channel.send(
-    `Added Unassigned role to ${missedUsers.size} members of the server!`
-  );
-
-  const whoopsUsers = guild.members.cache
-    .filter((member) =>
-      member.roles.cache.some((role) => role.id === UnassignedRole.id)
-    )
-    .filter((member) => member.roles.cache.size > 2); // @everyone + Unassigned + at least another role.
-  whoopsUsers.forEach((member) => member.roles.remove(UnassignedRole));
-  message.channel.send(
-    `Removed Unassigned role from ${whoopsUsers.size} members of the server!`
-  );
-}
+export const UnassignedMemberUpdate = (
+  newMember: GuildMember | PartialGuildMember
+) => {
+  const Unassigned = getUnassignedRole(newMember.guild);
+  newMember.roles.remove(Unassigned);
+};

--- a/src/programs/WhereAreYouFromManager.ts
+++ b/src/programs/WhereAreYouFromManager.ts
@@ -2,6 +2,7 @@ import { Guild, Message, Role, TextChannel, User } from "discord.js";
 import { isRegistered, textLog } from "../common/moderator";
 import { Country, countries } from "../collections/flagEmojis";
 import { MODERATOR_ROLE_NAME } from "../const";
+import { Unassigned } from ".";
 
 export default async function WhereAreYouFromManager(pMessage: Message) {
   const newUser = !isRegistered(pMessage.member);
@@ -46,6 +47,7 @@ export default async function WhereAreYouFromManager(pMessage: Message) {
           pMessage.guild.channels.cache.find((c) => c.name === "welcome-chat")
         );
         welcomeChat.send(getWelcomeMessage(pMessage.member.user));
+        Unassigned.UnassignedMemberUpdate(pMessage.member);
         dmChannel.send(
           `Hey! My name is YesBot, I'm so happy to see you've made it into our world, we really hope you stick around!\n\nIn the meantime, you should checkout ${rules.toString()} and ${generalInfo.toString()} , they contain a lot of good-to-knows about our server and what cool stuff you can do.\nIf you'd like me to change your name on the server for you, just drop me a message and I will help you out! Then I can introduce you to our family :grin:\n\nI know Discord can be a lot to take in at first, trust me, but it's really quite a wonderful place.`
         );

--- a/src/programs/index.ts
+++ b/src/programs/index.ts
@@ -20,7 +20,7 @@ import Someone from "./Someone";
 import StateRoleFinder from "./StateRoleFinder";
 import Ticket from "./Ticket";
 import TopicManager from "./TopicManager";
-import Unassigned from "./Unassigned";
+import * as Unassigned from "./Unassigned";
 import VoiceOnDemand from "./VoiceOnDemand";
 import * as VoiceOnDemandTools from "./VoiceOnDemand";
 import WhereAreYouFromManager from "./WhereAreYouFromManager";


### PR DESCRIPTION
This PR creates the base for the future slow transition to all users without country role having the Unassigned role. This update is mandatory before starting to "migrate" old users to ensure that only one pass over all users is required (hopefully... fingers crossed).