### PR TITLE
feat/unassigned migration

### DIFF
--- a/src/scripts/unassignedMigration.ts
+++ b/src/scripts/unassignedMigration.ts
@@ -83,6 +83,10 @@ const main = async () => {
   console.log(`Loaded ${countryRoles.length} country roles`);
 
   const unassignedRole = guild.roles.resolve(roleId);
+  if (!unassignedRole) {
+    throw new Error("Couldn't find role with id " + roleId);
+  }
+
   const { lastMaxUserId } = await loadStoredInformation();
 
   console.log("Loaded lastMaxUserId:", lastMaxUserId);

--- a/src/scripts/unassignedMigration.ts
+++ b/src/scripts/unassignedMigration.ts
@@ -107,7 +107,8 @@ const main = async () => {
 
     for (let i = 0; i < guildMembers.length; i++) {
       const m = guildMembers[i];
-      console.log(`Migrating users... Progress: ${i}/${guildMembers.length}`);
+      if (i % 20 === 0 && i !== 0)
+        console.log(`Migrating users... Progress: ${i}/${guildMembers.length}`);
       await m.roles.add(unassignedRole);
     }
 

--- a/src/scripts/unassignedMigration.ts
+++ b/src/scripts/unassignedMigration.ts
@@ -8,7 +8,10 @@ import { writeFile, readFile } from "fs";
 import { get, RequestOptions } from "https";
 
 const [, , guildId, roleId, token, limit] = process.argv;
-const bot = new Client({ ws: { intents: ["GUILD_MEMBERS"] } });
+const bot = new Client({
+  ws: { intents: ["GUILD_MEMBERS"] },
+  presence: { status: "invisible" },
+});
 
 interface StoredInformation {
   lastMaxUserId: string;

--- a/src/scripts/unassignedMigration.ts
+++ b/src/scripts/unassignedMigration.ts
@@ -1,0 +1,128 @@
+/*
+ * This file does not make use of the bot in this repository but is tracked here for documentation and versioning purposes.
+ * The code in this file is ran as single scheduled job and is fully self-contained.
+ */
+
+import { Client, PartialGuildMember, Guild, Snowflake } from "discord.js";
+import { writeFile, readFile } from "fs";
+import { get, RequestOptions } from "https";
+
+const [, , guildId, roleId, token, limit] = process.argv;
+const bot = new Client({ ws: { intents: ["GUILD_MEMBERS"] } });
+
+interface StoredInformation {
+  lastMaxUserId: string;
+}
+
+const infoPath = "./unassignedMigration.json";
+
+const loadStoredInformation = async (): Promise<StoredInformation> => {
+  return new Promise((res, rej) => {
+    readFile(infoPath, { encoding: "utf8" }, (err, data) => {
+      if (err) rej(err);
+      else res(JSON.parse(data));
+    });
+  });
+};
+
+const saveStoredInformation = (info: StoredInformation) => {
+  writeFile(infoPath, JSON.stringify(info), () =>
+    console.log("Completed write!")
+  );
+};
+
+const getMembers = async (lastId: String) => {
+  const query = `?limit=${limit}&after=${lastId}`;
+  const path = `/api/guilds/${guildId}/members${query}`;
+  console.log("Loading members from ", path);
+
+  const options: RequestOptions = {
+    host: "discord.com",
+    path,
+    headers: {
+      Authorization: "Bot " + token,
+    },
+  };
+
+  return new Promise((res, rej) => {
+    const req = get(options, (response) => {
+      let data = "";
+
+      response.on("data", (datum) => (data += datum));
+      response.on("end", () => {
+        console.log("Request completed with statuscode", response.statusCode);
+        if (response.statusCode === 200) res(JSON.parse(data));
+        else rej({ statusCode: response.statusCode, error: data });
+      });
+    });
+
+    req.on("error", rej);
+  });
+};
+
+const getCountryRoles = async (guild: Guild): Promise<Snowflake[]> => {
+  const updatedManager = await guild.roles.fetch();
+  const prefix = "I'm from ";
+  return updatedManager.cache
+    .filter((role) => role.name.startsWith(prefix))
+    .map((role) => role.id);
+};
+
+const main = async () => {
+  console.log("Script started...");
+
+  const guild = bot.guilds.resolve(guildId);
+  if (guild === null) {
+    throw new Error("Couldn't find guild with id " + guildId);
+  }
+
+  const countryRoles = await getCountryRoles(guild);
+  console.log(`Loaded ${countryRoles.length} country roles`);
+
+  const unassignedRole = guild.roles.resolve(roleId);
+  const { lastMaxUserId } = await loadStoredInformation();
+
+  console.log("Loaded lastMaxUserId:", lastMaxUserId);
+
+  try {
+    const members = (await getMembers(lastMaxUserId)) as PartialGuildMember[];
+    const filteredMembers = members
+      .filter((member) =>
+        ((member.roles as unknown) as string[]).every(
+          (roleId) => !countryRoles.includes(roleId)
+        )
+      )
+      .map((member) => member.user.id);
+
+    const guildMembers = (
+      await guild.members.fetch({ user: filteredMembers })
+    ).array();
+
+    for (let i = 0; i < guildMembers.length; i++) {
+      const m = guildMembers[i];
+      console.log(`Migrating users... Progress: ${i}/${guildMembers.length}`);
+      await m.roles.add(unassignedRole);
+    }
+
+    console.log(
+      `Loaded ${members.length} members, migrated ${filteredMembers.length}.`
+    );
+
+    if (members.length) {
+      const maxUserId = members[members.length - 1].user.id;
+
+      saveStoredInformation({
+        lastMaxUserId: maxUserId,
+      });
+    } else {
+      // TODO: Disable scheduling and notify support to double check
+      console.log("Completed!");
+    }
+  } finally {
+    console.log("Closing down bot!");
+    setTimeout(() => bot.destroy(), 3000);
+  }
+};
+
+bot.on("ready", main);
+bot.login(token);

--- a/src/scripts/unassignedMigration.ts
+++ b/src/scripts/unassignedMigration.ts
@@ -165,10 +165,12 @@ const main = async () => {
   try {
     const members = (await getMembers(lastMaxUserId)) as PartialGuildMember[];
     const filteredMembers = members
-      .filter((member) =>
-        ((member.roles as unknown) as string[]).every(
-          (roleId) => !countryRoles.includes(roleId)
-        )
+      .filter(
+        (member) =>
+          !member.user.bot &&
+          ((member.roles as unknown) as string[]).every(
+            (roleId) => !countryRoles.includes(roleId)
+          )
       )
       .map((member) => member.user.id);
 


### PR DESCRIPTION
This PR introduces a script to the codebase that is not run under the same bot account as everything else. The reason it's added is for documentation and versioning.

To make use of server templates again, all unassigned users need to be migrated to have an Unassigned role. This script is designed to do this migration in smaller steps by running it in regular intervals.

The script takes four arguments.
 - guildId: ID of the server the operation should be run on
 - roleId: ID of the role indicating an Unassigned member
 - botToken: Token of the bot account used
 - limit: Amount of members to query and "migrate"

The script requires the Server Members Privileged Intent to be enabled on the bot page of the Discord Application.

To avoid API spam, the country roles are prefeched once and later used for filtering queried members. The script then loads `limit` members from the API. The response contains the members' roles which can be used to filter out only those users who don't have any role that also occurs in the prefetched country role id list (= are unassigned). The resulting members are converted to their ID and requests are made to assign them the role defined by the `roleId` in the guild defined by `guildId`.
In order to not fetch the same members over and over again, the query for members is using an `after` query parameter to only get members that have a user id *after* `after`. That value is kept track of by storing the last fetched userId in a JSON file which is loaded on script start.

To run the script, a file called `unassignedMigration.json` needs to be placed in the pwd of the script with the content `{"lastMaxUserId":"0"}`.

When the script's query for members returns no results, the script disables the timer running it automatically and reports completion to the Server Engineers.  
The same thing happens when the script encounters a status code !== 200 when querying with special output when hitting a rate limit response (429).