### PR TITLE
fix: ignore Unassigned role when handling seperators

### DIFF
--- a/src/events/GuildMemberUpdate.ts
+++ b/src/events/GuildMemberUpdate.ts
@@ -56,6 +56,8 @@ class GuildMemberUpdate {
       unlockCountryChannels(newMember);
     }
 
+    if (gainedRole(oldMember, newMember, "Unassigned")) return;
+
     NitroColors.removeColorIfNotAllowed(newMember);
     Separators.seperatorOnRoleAdd(oldMember, newMember);
     Separators.seperatorOnRoleRemove(oldMember, newMember);


### PR DESCRIPTION
This is to reduce the overhead of the bot adding and removing a bunch of roles both in normal operation as well as during the migration to the Unassigned role.