### PR TITLE
fix: broken poll reactions for deleted reactions

### DIFF
--- a/src/programs/PollsManager.ts
+++ b/src/programs/PollsManager.ts
@@ -22,8 +22,8 @@ export const ModeratorPollMirror = async (
   const member = channel.guild.member(user.id);
 
   if (!hasRole(member, "Support")) return;
-  const { count } = await reaction.fetch();
-  if (count > 1) return;
+  const fetched = await reaction.users.fetch();
+  if (fetched.size > 1) return;
 
   message.react(reaction.emoji);
   reaction.users.remove(user.id);


### PR DESCRIPTION
This fixes a rare edge case when a mod has to delete previous reactions and add them again later. For some reason the count property of the freshly fetched and updated reaction object contains the wrong value in the following scenario

1. Add the reaction
2. Bot reacts properly
3. Clear that reaction from all users
4. Add the reaction again
5. reaction#count is 2 instead of 1

The code now doesn't fetch the reaction but the users and uses the size of that collection to determine whether something was the first reaction of a kind or not.