### PR TITLE
fix: Proper message when member is null

### DIFF
--- a/src/events/ReactionAdd.ts
+++ b/src/events/ReactionAdd.ts
@@ -89,8 +89,10 @@ class ReactionAdd {
         reaction: this.reaction,
       },
     });
-    reactRoleObjects.forEach((reactionRole) => {
-      const guildMember = this.guild.member(this.user);
+    reactRoleObjects.forEach(async (reactionRole) => {
+      const guildMember =
+        this.guild.member(this.user) ??
+        (await this.guild.members.fetch(this.user));
       const roleToAdd = this.guild.roles.resolve(reactionRole.roleId);
 
       if (


### PR DESCRIPTION
For some reason guildMember is null in extremely rare cases and I don't know why so we just provide a proper error message until it's figured out.