### PR TITLE
feat: template-mode

### DIFF
--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -19,6 +19,7 @@ import {
   Resource,
   Someone,
   StateRoleFinder,
+  TemplateMode,
   Ticket,
   TopicManager,
   VoiceOnDemand,
@@ -124,6 +125,7 @@ class MessageManager {
         )
           GroupManager(this.message, true);
         if (firstWord === "!profile") ProfileManager(this.message);
+        if (firstWord === "!templateMode") TemplateMode(this.message);
         break;
 
       case "bot-commands":

--- a/src/programs/TemplateMode.ts
+++ b/src/programs/TemplateMode.ts
@@ -1,0 +1,192 @@
+import {
+  Message,
+  Guild,
+  TextChannel,
+  OverwriteResolvable,
+  PermissionOverwriteOption,
+} from "discord.js";
+import Tools from "../common/tools";
+
+const targetChannelNames = [
+  {
+    name: "start-here",
+    readOnly: true,
+  },
+  { name: "flag-drop", readOnly: false },
+];
+
+const templateMode = async (message: Message) => {
+  const arg = message.content.split(" ")[1];
+  switch (arg) {
+    case "on":
+      await applyPermissions(message.guild, on);
+      break;
+    case "off":
+      await applyPermissions(message.guild, off);
+      break;
+    default:
+      return Tools.handleUserError(message, "Argument must be on or off!");
+  }
+
+  message.reply("Completed.");
+};
+
+const on = async (
+  guild: Guild,
+  readOnly: boolean
+): Promise<OverwriteResolvable[]> => {
+  const unassignedRole = Tools.getRoleByName("Unassigned", guild);
+  return [
+    {
+      type: "role",
+      id: unassignedRole.id,
+      allow: ["VIEW_CHANNEL", readOnly ? 0 : "SEND_MESSAGES"],
+    },
+    {
+      type: "role",
+      id: guild.roles.everyone.id,
+      deny: "VIEW_CHANNEL",
+    },
+  ];
+};
+
+const off = async (guild: Guild, readOnly: boolean) => {
+  const updatedManager = await guild.roles.fetch();
+  const prefix = "I'm from ";
+  const countryRoles = updatedManager.cache
+    .filter((role) => role.name.startsWith(prefix))
+    .map((role) => role.id);
+
+  const toWelcomePermissions = (id: string): OverwriteResolvable => {
+    return {
+      id,
+      type: "role",
+      deny: "VIEW_CHANNEL",
+    };
+  };
+
+  const unassignedRole = Tools.getRoleByName("Unassigned", guild);
+  // Duplicate entry for everyone is intended to ensure everyone is denied read access until all country permissions are set
+  const permissions: OverwriteResolvable[] = [
+    {
+      type: "role",
+      id: unassignedRole.id,
+      allow: ["VIEW_CHANNEL", readOnly ? 0 : "SEND_MESSAGES"],
+    },
+    {
+      id: guild.roles.everyone.id,
+      type: "role",
+      deny: "VIEW_CHANNEL",
+    },
+    ...countryRoles.map(toWelcomePermissions),
+    {
+      id: guild.roles.everyone.id,
+      type: "role",
+      allow: "VIEW_CHANNEL",
+      deny: readOnly ? "SEND_MESSAGES" : 0,
+    },
+  ];
+
+  return permissions;
+};
+
+type PermissionFunction = (
+  guild: Guild,
+  readOnly: boolean
+) => Promise<OverwriteResolvable[]>;
+
+const applyPermissions = async (
+  guild: Guild,
+  permissionFunction: PermissionFunction
+) => {
+  const channels = guild.channels.cache
+    .filter((c) => targetChannelNames.map((n) => n.name).includes(c.name))
+    .array();
+  for (const channel of channels) {
+    if (!(channel instanceof TextChannel)) return;
+    const readOnly = targetChannelNames.find(
+      (entry) => entry.name === channel.name
+    ).readOnly;
+    const permissions = [
+      ...alwaysPresent(guild),
+      ...(await permissionFunction(guild, readOnly)),
+    ];
+
+    // Find Germany and shut it down once and for all!
+    const firstHundred = permissions.splice(0, 100);
+    await channel.overwritePermissions(
+      firstHundred,
+      "Restructuring for the template."
+    );
+
+    for (const perm of permissions) {
+      await channel.updateOverwrite(
+        perm.id,
+        overwriteToPermissionOverwriteOption(perm)
+      );
+    }
+  }
+};
+
+const alwaysPresent = (guild: Guild): OverwriteResolvable[] => {
+  const support = Tools.getRoleByName("Support", guild);
+  const timeOut = Tools.getRoleByName("Time Out", guild);
+  const dyno = Tools.getRoleByName("Dyno", guild);
+
+  return [
+    {
+      id: support.id,
+      allow: ["VIEW_CHANNEL", "SEND_MESSAGES"],
+      type: "role",
+    },
+    {
+      id: timeOut.id,
+      deny: "SEND_MESSAGES",
+      type: "role",
+    },
+    {
+      id: dyno.id,
+      allow: "VIEW_CHANNEL",
+      type: "role",
+    },
+  ];
+};
+
+const overwriteToPermissionOverwriteOption = (
+  overwrite: OverwriteResolvable
+): PermissionOverwriteOption => {
+  let read = null;
+  let send = null;
+
+  if (
+    overwrite.allow === "VIEW_CHANNEL" ||
+    (Array.isArray(overwrite.allow) && overwrite.allow.includes("VIEW_CHANNEL"))
+  )
+    read = true;
+
+  if (
+    overwrite.allow === "SEND_MESSAGES" ||
+    (Array.isArray(overwrite.allow) &&
+      overwrite.allow.includes("SEND_MESSAGES"))
+  )
+    send = true;
+
+  if (
+    overwrite.deny === "VIEW_CHANNEL" ||
+    (Array.isArray(overwrite.deny) && overwrite.deny.includes("VIEW_CHANNEL"))
+  )
+    read = false;
+
+  if (
+    overwrite.deny === "SEND_MESSAGES" ||
+    (Array.isArray(overwrite.deny) && overwrite.deny.includes("SEND_MESSAGES"))
+  )
+    send = false;
+
+  return {
+    VIEW_CHANNEL: read,
+    SEND_MESSAGES: send,
+  };
+};
+
+export default templateMode;

--- a/src/programs/index.ts
+++ b/src/programs/index.ts
@@ -18,6 +18,7 @@ import ReactRole from "./ReactRole";
 import Resource from "./ResourceManager";
 import Someone from "./Someone";
 import StateRoleFinder from "./StateRoleFinder";
+import TemplateMode from "./TemplateMode";
 import Ticket from "./Ticket";
 import TopicManager from "./TopicManager";
 import * as Unassigned from "./Unassigned";
@@ -46,6 +47,7 @@ export {
   Separators,
   Someone,
   StateRoleFinder,
+  TemplateMode,
   Ticket,
   TopicManager,
   Unassigned,


### PR DESCRIPTION
Adds a new command that allows switching channel permissions of start-here and flag-drop to "Template Mode" that allows creating a server template.

This is done by switching to a different set of permissions that shows and hides the channels for the same people but that allows creating a server template through the use of less permission overwrites when required.

That setup however causes several Server Discovery features to fail so it should not be active when not required.

`!templateMode on` Changes the permissions to a set that allows creating a server template (takes a few seconds)
`!templateMode off` Changes the permissions to a set that allows use of Server Discovery (takes around 5 minutes to complete)
