### PR TITLE
fix: there not being a challenge 8 hours before a new one

### DIFF
--- a/src/programs/SendFromDB.ts
+++ b/src/programs/SendFromDB.ts
@@ -16,20 +16,14 @@ export default async function SendFromDB(
   }
 
   if (repo) {
-    const today = new Date();
-    today.setUTCHours(0, 0, 0, 0);
-    const yesterday = new Date();
-    yesterday.setUTCHours(0, 0, 0, 0);
-    yesterday.setDate(today.getDate() - 1);
+    const compare = new Date();
+    compare.setUTCHours(compare.getUTCHours() - 48 - 8);
 
     const res = await repo
       .createQueryBuilder()
       .select()
-      .where("last_used = :today", {
-        today: today.toISOString(),
-      })
-      .orWhere("last_used = :yesterday", {
-        yesterday: yesterday.toISOString(),
+      .where("last_used > :today", {
+        today: compare.toISOString(),
       })
       .getOne();
 


### PR DESCRIPTION
Because the bot saves challenges as used at 00:00 of the day they were posted but they are posted with 8 hours offset, they is no challenge in the 8 hours before a new one is posted.

This is now mitigated by doing a comparison with the datetime 2 days and 8 hours back and taking the (hopefully only) one challenge that has a last_used date after that.
