### PR TITLE
fix: polls breaking with numbers and certain emojis

### DIFF
--- a/src/programs/PollsManager.ts
+++ b/src/programs/PollsManager.ts
@@ -1,11 +1,11 @@
 import {
+  Client,
+  DMChannel,
+  EmojiResolvable,
   Message,
   MessageReaction,
-  DMChannel,
-  User,
   PartialUser,
-  EmojiResolvable,
-  Client,
+  User,
 } from "discord.js";
 import { hasRole } from "../common/moderator";
 
@@ -31,7 +31,10 @@ const getEmojis = (lines: string[], bot: Client): string[] => {
     }
   }
 
-  return result;
+  return result.filter((emoji) => {
+    const isNumber = /^\d$/.test(emoji);
+    return !isNumber;
+  });
 };
 
 const letterToEmoji = (letter: string) => {
@@ -56,7 +59,12 @@ const resolveEmojis = (lines: string[], bot: Client): EmojiResolvable[] => {
   const emojiEmojis = getEmojis(lines, bot);
 
   if (emojiEmojis && emojiEmojis.length > 0) {
-    return emojiEmojis;
+    return emojiEmojis.map((emoji) =>
+      emoji
+        .split("")
+        .filter((c) => c.charCodeAt(0) !== 65039)
+        .join("")
+    );
   }
 
   const letterEmojis = getLetterEmojis(lines);
@@ -83,7 +91,10 @@ export default async function PollsManager(pMessage: Message) {
   }
 
   const lines = pMessage.cleanContent.split("\n");
-  const resolvedEmojis = resolveEmojis(lines.map(removeSpecialCharactersFromBeginning), pMessage.client);
+  const resolvedEmojis = resolveEmojis(
+    lines.map(removeSpecialCharactersFromBeginning),
+    pMessage.client
+  );
   const unique = resolvedEmojis.filter(
     (e, i) => resolvedEmojis.indexOf(e) === i
   );
@@ -101,8 +112,8 @@ export default async function PollsManager(pMessage: Message) {
 }
 
 const removeSpecialCharactersFromBeginning = (content: string) => {
-  return content.replace(/^\p{P}*/u, '');
-}
+  return content.replace(/^\p{P}*/u, "");
+};
 
 export const ModeratorPollMirror = async (
   reaction: MessageReaction,


### PR DESCRIPTION
In two edge cases the bot wasn't able to properly add reactions:

 - Numbers at the start of a line; since :one: is built in unicode as `1<some invisible character>`, digits have to match `\p{Emoji}` used in the regex to detect unicode emojis. This is fixed by filtering out single digit "emojis".

 - Emojis with a strange additional character after them. For some reason, some emojis sent in polls were sent with a character with codepoint 65039 causing Discord to reject the reaction. Dirty but working fix is to split emojis sent, filtering out the character with the problematic codepoint, joining the pieces and using that cleaned up version.