### PR TITLE
fixed bug #214

### DIFF
--- a/src/programs/VoiceOnDemand.ts
+++ b/src/programs/VoiceOnDemand.ts
@@ -526,7 +526,7 @@ const requestOwnershipTransfer = async (
   }
 
   const claimingUser = claim
-    ? claim.users.cache.filter((user) => !user.bot).first()
+    ? claim.users.cache.filter((user) => getMemberIds().includes(user.id)).first()
     : channel.members.random().user;
   await botCommands.send(
     `<@${claimingUser}>, is now the new owner of the room! You can now change the limit of it using \`!voice limit\`.`


### PR DESCRIPTION
Added the .first() at the end because it returned a collective string and that was big red everywhere
This was only tested with 3 accounts A and B in the voice channel and C not in the voice channel trying to claim
When A (Host left) C clicked on the claim message but once pressed by B it was given to B :)
Quick warning: With such a small testing team which is me and my other accounts that I call friends. I have no idea how this will work if there are multiple in the voice channel. 
But going off logic here seems okay? 