### PR TITLE
Fixes for issue #222 and issue #223

### DIFF
--- a/src/games/GameSession.ts
+++ b/src/games/GameSession.ts
@@ -20,6 +20,7 @@ export interface GameConfig<T extends SessionConfig> {
   minPlayers?: number;
   maxPlayers?: number;
   voiceRequired?: boolean;
+  dmsRequired?: boolean;
 }
 
 export interface SessionConfig {

--- a/src/games/spyfall/Spyfall.ts
+++ b/src/games/spyfall/Spyfall.ts
@@ -60,6 +60,7 @@ export class Spyfall extends GameSession<SpyfallSessionConfig> {
     rules,
     howToPlay,
     voiceRequired: true,
+    dmsRequired: true,
     minPlayers: 4,
     maxPlayers: 10,
     configuration: {

--- a/src/programs/GroupManager.ts
+++ b/src/programs/GroupManager.ts
@@ -311,7 +311,7 @@ const searchGroup = async (
   ).sort(byMemberCount);
 
   if (copy.length === 0) {
-    await message.reply("No matching groups were found.")
+    await message.reply("No matching groups were found.");
     return;
   }
 


### PR DESCRIPTION
The reason for this bug was because the bot is not able to send to the player a dm if they have it disabled in their privacy settings, it generated a bunch of errors in the log making a non-ending session.

Testing:
4 accounts to launch the game. 
- First Test: One account had their privacy disabled the bot send a message in #bot-games text channel saying the game couldn't start because of @{PLAYER WHO HAS "ALLOW DIRECT MESSAGES FROM SERVER MEMBERS" DISABLED} and wouldn't launch the game. Trying to open another game session immediately generated no bugs and also didn't allow the game to start.
- Second Test: All users had the right settings game launched with no issue, all commands work normally, the game runs with configurations being changeable. Tbh idk what I missed but doesn't feel like did...

Implementations:
Added a new configuration: redquiredDms (Allows you to run the validates function).
ValidateDms is a function that sends a text message to all players in the game to make sure they can receive a message
Updated Spyfall to use the new configuration.
Updated GameSession to use the new configuration.
Non imported I just added the `;` in the GroupManager because it pissed me off that I forgot about it.