### PR TITLE
fix: issue #223

### DIFF
--- a/src/games/GameHub.ts
+++ b/src/games/GameHub.ts
@@ -273,7 +273,7 @@ export default class GameHub {
       throw e;
     }
 
-    const minPlayers = clazz.config;
+    const minPlayers = clazz.config.minPlayers;
     const cleanedPlayers = await this.cleanPlayers(players);
     const permissions = this.getChannelPermissions(cleanedPlayers);
     const channel = await this.createChannel(config, permissions);
@@ -282,7 +282,7 @@ export default class GameHub {
       .map((member) => `<@${member.user.id}>`)
       .join(" ");
 
-    if (cleanedPlayers.length < clazz.config.minPlayers) {
+    if (cleanedPlayers.length < minPlayers) {
       await channel.send(
         `Not enough players! You need at least ${minPlayers} people.`
       );

--- a/src/games/GameHub.ts
+++ b/src/games/GameHub.ts
@@ -253,7 +253,7 @@ export default class GameHub {
         players.push(this.guild.member(leaderId));
       }
 
-      const { minPlayers, maxPlayers } = clazz.config;  
+      const { minPlayers, maxPlayers } = clazz.config;
       if (minPlayers && players.length < minPlayers) {
         // noinspection ExceptionCaughtLocallyJS
         throw new Error(
@@ -281,7 +281,7 @@ export default class GameHub {
 
     if (cleanedPlayers.length < minPlayers) {
       throw new Error(
-        `Not enough players! You need at least ${minPlayers} people.`
+        `Not enough players! You need at least ${minPlayers} people. Please make sure no players are in an ongoing game.`
       );
     }
 

--- a/src/games/GameHub.ts
+++ b/src/games/GameHub.ts
@@ -273,55 +273,60 @@ export default class GameHub {
       throw e;
     }
 
+    const minPlayers = clazz.config;
     const cleanedPlayers = await this.cleanPlayers(players);
-    if (cleanedPlayers.length >= clazz.config.minPlayers) {
-      const playerPing = cleanedPlayers
-        .map((member) => `<@${member.user.id}>`)
-        .join(" ");
+    const permissions = this.getChannelPermissions(cleanedPlayers);
+    const channel = await this.createChannel(config, permissions);
+    let maybeVoiceChannel;
+    const playerPing = cleanedPlayers
+      .map((member) => `<@${member.user.id}>`)
+      .join(" ");
 
-      const permissions = this.getChannelPermissions(cleanedPlayers);
-      const channel = await this.createChannel(config, permissions);
-      let maybeVoiceChannel;
-
-      if (clazz.config.voiceRequired) {
-        maybeVoiceChannel = await this.createVoiceChannel(config, permissions);
-      }
-
+    if (cleanedPlayers.length < clazz.config.minPlayers) {
       await channel.send(
-        `**${playerPing}, welcome to a game of ${config.name}!**`
+        `Not enough players! You need at least ${minPlayers} people.`
       );
-
-      if (maybeVoiceChannel) {
-        await channel.send(
-          "I created a voice channel for you that you should be able to see in the Bot Games category"
-        );
-      }
-
-      session.Configuration(
-        channel,
-        cleanedPlayers,
-        leaderId,
-        maybeVoiceChannel
-      );
-      this.sessions[channel.id] = session;
-
-      if (clazz.config.configuration) {
-        await channel.send(
-          `<@${leaderId}> is game leader, please configure the game!`
-        );
-
-        const configurator = new GameConfigurator(
-          clazz.config.configuration,
-          config.name,
-          leaderId,
-          channel
-        );
-        const gameConfig = await configurator.createConfiguration();
-        await session.patchConfig(gameConfig);
-      }
-
-      session.start();
+      return;
     }
+
+    if (clazz.config.voiceRequired) {
+      maybeVoiceChannel = await this.createVoiceChannel(config, permissions);
+    }
+
+    await channel.send(
+      `**${playerPing}, welcome to a game of ${config.name}!**`
+    );
+
+    if (maybeVoiceChannel) {
+      await channel.send(
+        "I created a voice channel for you that you should be able to see in the Bot Games category"
+      );
+    }
+
+    session.setBaseConfiguration(
+      channel,
+      cleanedPlayers,
+      leaderId,
+      maybeVoiceChannel
+    );
+    this.sessions[channel.id] = session;
+
+    if (clazz.config.configuration) {
+      await channel.send(
+        `<@${leaderId}> is game leader, please configure the game!`
+      );
+
+      const configurator = new GameConfigurator(
+        clazz.config.configuration,
+        config.name,
+        leaderId,
+        channel
+      );
+      const gameConfig = await configurator.createConfiguration();
+      await session.patchConfig(gameConfig);
+    }
+
+    session.start();
   }
 
   // Because of the way we "route" DMs to the game sessions, members may only be in a single session at once.

--- a/src/games/GameHub.ts
+++ b/src/games/GameHub.ts
@@ -253,7 +253,7 @@ export default class GameHub {
         players.push(this.guild.member(leaderId));
       }
 
-      const { minPlayers, maxPlayers } = clazz.config;
+      const { minPlayers, maxPlayers } = clazz.config;  
       if (minPlayers && players.length < minPlayers) {
         // noinspection ExceptionCaughtLocallyJS
         throw new Error(
@@ -275,19 +275,19 @@ export default class GameHub {
 
     const minPlayers = clazz.config.minPlayers;
     const cleanedPlayers = await this.cleanPlayers(players);
-    const permissions = this.getChannelPermissions(cleanedPlayers);
-    const channel = await this.createChannel(config, permissions);
-    let maybeVoiceChannel;
     const playerPing = cleanedPlayers
       .map((member) => `<@${member.user.id}>`)
       .join(" ");
 
     if (cleanedPlayers.length < minPlayers) {
-      await channel.send(
+      throw new Error(
         `Not enough players! You need at least ${minPlayers} people.`
       );
-      return;
     }
+
+    const permissions = this.getChannelPermissions(cleanedPlayers);
+    const channel = await this.createChannel(config, permissions);
+    let maybeVoiceChannel;
 
     if (clazz.config.voiceRequired) {
       maybeVoiceChannel = await this.createVoiceChannel(config, permissions);

--- a/src/games/GameSession.ts
+++ b/src/games/GameSession.ts
@@ -93,8 +93,7 @@ export abstract class GameSession<T extends SessionConfig> {
       .map((user) => this.hub.guild.members.resolve(user.id));
   }
 
-  public async patchConfig(
-    partial: Partial<T>,
+  public async Configuration(
     channel: TextChannel,
     players: GuildMember[],
     leaderId: Snowflake,
@@ -104,7 +103,9 @@ export abstract class GameSession<T extends SessionConfig> {
     this.sessionConfig.voiceChannel = voiceChannel;
     this.sessionConfig.players = [...players];
     this.sessionConfig.leaderId = leaderId;
+  }
 
+  public async patchConfig(partial: Partial<T>): Promise<void> {
     if (this.sessionConfig) {
       this.sessionConfig = { ...this.sessionConfig, ...partial };
     } else {

--- a/src/games/GameSession.ts
+++ b/src/games/GameSession.ts
@@ -93,12 +93,12 @@ export abstract class GameSession<T extends SessionConfig> {
       .map((user) => this.hub.guild.members.resolve(user.id));
   }
 
-  public async Configuration(
+  public setBaseConfiguration(
     channel: TextChannel,
     players: GuildMember[],
     leaderId: Snowflake,
     voiceChannel: VoiceChannel | undefined
-  ): Promise<void> {
+  ) {
     this.sessionConfig.channel = channel;
     this.sessionConfig.voiceChannel = voiceChannel;
     this.sessionConfig.players = [...players];

--- a/src/games/spyfall/Spyfall.ts
+++ b/src/games/spyfall/Spyfall.ts
@@ -121,23 +121,17 @@ export class Spyfall extends GameSession<SpyfallSessionConfig> {
     activeVote: false,
   };
 
-  async patchConfig(
-    partial: Partial<SpyfallSessionConfig>,
-    channel: TextChannel,
-    players: GuildMember[],
-    leaderId: Snowflake,
-    voiceChannel: VoiceChannel | undefined
-  ) {
+  async patchConfig(partial: Partial<SpyfallSessionConfig>) {
     const nos = partial.numberOfSpies;
-    if (nos && Math.ceil(players.length / nos) <= 2) {
-      const sensibleDefault = Math.floor(players.length / 2) - 1;
-      await channel.send(
+    if (nos && Math.ceil(this.players.length / nos) <= 2) {
+      const sensibleDefault = Math.floor(this.players.length / 2) - 1;
+      await this.channel.send(
         `Configuration set a value of ${nos} spies which is equal to or more than half the amount of players which automatically wins the spies the game. Setting the number to ${sensibleDefault} to make the game playable.`
       );
       partial.numberOfSpies = sensibleDefault;
     }
 
-    await super.patchConfig(partial, channel, players, leaderId, voiceChannel);
+    await super.patchConfig(partial);
   }
 
   async start() {


### PR DESCRIPTION
Testing:

Tested users currently in a game and if they can be invited by user C, the double-check for issue #223 basically
Tested users cannot be invited to a new game if on the configuration page

Implementation:

In file: GameHub.ts, added the if to check if cleanPlayers is bigger or equal to the minimum of players required before starting the game.
In these files: GameHub.ts, GameSession.ts, and Spyfall.ts. Added the new property called Configuration. Basically split the patch config to avoid users being invited to a new game while on the configuration page of the game.
