### PR TITLE
feat: new member role and #147

### DIFF
--- a/src/events/GuildMemberUpdate.ts
+++ b/src/events/GuildMemberUpdate.ts
@@ -10,7 +10,7 @@ import {
 } from "discord.js";
 import Tools from "../common/tools";
 import { hasRole } from "../common/moderator";
-import { Separators, NitroColors } from "../programs";
+import { Separators, NitroColors, WhereAreYouFromManager } from "../programs";
 import prisma from "../prisma";
 
 class GuildMemberUpdate {
@@ -20,23 +20,6 @@ class GuildMemberUpdate {
     oldMember: GuildMember | PartialGuildMember,
     newMember: GuildMember | PartialGuildMember
   ) {
-    const regionCountries = ["Australia", "Canada", "the UK", "the USA"];
-    const findGeneralRole = (member: GuildMember | PartialGuildMember) =>
-      member.roles.cache.find(({ name }) => {
-        return regionCountries.some((country) => name.endsWith(`${country}!`));
-      });
-    const hasSpecificRole = (member: GuildMember | PartialGuildMember) =>
-      member.roles.cache.some(({ name }) => {
-        return regionCountries.some((country) =>
-          name.includes(`${country}! (`)
-        );
-      });
-
-    const generalRole = findGeneralRole(oldMember);
-    if (generalRole && hasSpecificRole(newMember)) {
-      newMember.roles.remove(generalRole);
-    }
-
     if (
       gainedRole(oldMember, newMember, "Time Out") ||
       gainedRole(oldMember, newMember, "Break")
@@ -56,8 +39,14 @@ class GuildMemberUpdate {
       unlockCountryChannels(newMember);
     }
 
-    if (gainedRole(oldMember, newMember, "Unassigned")) return;
+    if (
+      gainedRole(oldMember, newMember, "Unassigned") ||
+      gainedRole(oldMember, newMember, "Member")
+    ) {
+      return;
+    }
 
+    WhereAreYouFromManager.updateAfterRegionSelect(oldMember, newMember);
     NitroColors.removeColorIfNotAllowed(newMember);
     Separators.separatorOnRoleAdd(oldMember, newMember);
     Separators.separatorOnRoleRemove(oldMember, newMember);

--- a/src/events/MessageManager.ts
+++ b/src/events/MessageManager.ts
@@ -114,7 +114,7 @@ class MessageManager {
         }
         break;
       case "flag-drop":
-        await WhereAreYouFromManager(this.message);
+        await WhereAreYouFromManager.default(this.message);
         break;
 
       case "chat":

--- a/src/programs/WhereAreYouFromManager.ts
+++ b/src/programs/WhereAreYouFromManager.ts
@@ -45,6 +45,10 @@ export default async function WhereAreYouFromManager(pMessage: Message) {
       }
       await pMessage.member.roles.add(roleToAssign);
       await pMessage.react("👍");
+      const isCountryWithRegionRole = regionCountries.some((country) =>
+        roleToAssign.name.endsWith(`${country}!`)
+      );
+
       pMessage.member.createDM().then((dmChannel) => {
         const rules = pMessage.guild.channels.cache.find(
           (c) => c.name === "rules"
@@ -53,9 +57,6 @@ export default async function WhereAreYouFromManager(pMessage: Message) {
           (c) => c.name === "general-info"
         );
 
-        const isCountryWithRegionRole = regionCountries.some((country) =>
-          roleToAssign.name.endsWith(`${country}!`)
-        );
         if (!isCountryWithRegionRole) {
           welcomeMember(pMessage.member.user, pMessage.member.guild);
         }
@@ -64,17 +65,13 @@ export default async function WhereAreYouFromManager(pMessage: Message) {
           `Hey! My name is YesBot, I'm so happy to see you've made it into our world, we really hope you stick around!\n\nIn the meantime, you should checkout ${rules.toString()} and ${generalInfo.toString()} , they contain a lot of good-to-knows about our server and what cool stuff you can do.\nIf you'd like me to change your name on the server for you, just drop me a message and I will help you out! Then I can introduce you to our family :grin:\n\nI know Discord can be a lot to take in at first, trust me, but it's really quite a wonderful place.`
         );
       });
-      if (roleToAssign.name === "I'm from Australia!") {
-        ghostPing(pMessage, "Australia");
-      }
-      if (roleToAssign.name === "I'm from the USA!") {
-        ghostPing(pMessage, "USA");
-      }
-      if (roleToAssign.name === "I'm from Canada!") {
-        ghostPing(pMessage, "Canada");
-      }
-      if (roleToAssign.name === "I'm from the UK!") {
-        ghostPing(pMessage, "UK");
+
+      if (isCountryWithRegionRole) {
+        const countryFromRoleNameRegex = /.*\s(.*)!$/;
+        const lowerCaseCountry = roleToAssign.name
+          .match(countryFromRoleNameRegex)[1]
+          .toLowerCase();
+        await ghostPing(pMessage, lowerCaseCountry);
       }
     }
   }
@@ -144,42 +141,12 @@ export const getRoleForCountry = (country: Country, guild: Guild): Role => {
   }
 };
 
-export const ghostPing = async (message: Message, region: String) => {
-  const ausRegionChannel = message.guild.channels.cache.find(
-    (channel) => channel.name === "australia-regions"
+const ghostPing = async (message: Message, region: String) => {
+  const regionChannel = message.guild.channels.cache.find(
+    (channel) => channel.name === `${region}-regions`
   ) as TextChannel;
-
-  const usaRegionChannel = message.guild.channels.cache.find(
-    (channel) => channel.name === "usa-regions"
-  ) as TextChannel;
-
-  const caRegionChannel = message.guild.channels.cache.find(
-    (channel) => channel.name === "canada-regions"
-  ) as TextChannel;
-
-  const ukRegionChannel = message.guild.channels.cache.find(
-    (channel) => channel.name === "uk-regions"
-  ) as TextChannel;
-
-  if (region === "Australia") {
-    const ping = await ausRegionChannel.send(`<@${message.member}>`);
-    await ping.delete();
-  }
-
-  if (region === "USA") {
-    const ping = await usaRegionChannel.send(`<@${message.member}>`);
-    await ping.delete();
-  }
-
-  if (region === "Canada") {
-    const ping = await caRegionChannel.send(`<@${message.member}>`);
-    await ping.delete();
-  }
-
-  if (region === "UK") {
-    const ping = await ukRegionChannel.send(`<@${message.member}>`);
-    await ping.delete();
-  }
+  const ping = await regionChannel.send(`<@${message.member}>`);
+  await ping.delete();
 };
 
 export const getCountriesFromMessage = (message: string) => {

--- a/src/programs/index.ts
+++ b/src/programs/index.ts
@@ -10,6 +10,7 @@ import * as TopicManager from "./TopicManager";
 import * as Unassigned from "./Unassigned";
 import * as Valentine from "./Valentine";
 import * as VoiceOnDemandTools from "./VoiceOnDemand";
+import * as WhereAreYouFromManager from "./WhereAreYouFromManager";
 import AdventureGame from "./AdventureGame";
 import BirthdayManager from "./BirthdayManager";
 import Deadchat from "./Deadchat";
@@ -24,7 +25,6 @@ import Someone from "./Someone";
 import TemplateMode from "./TemplateMode";
 import Ticket from "./Ticket";
 import VoiceOnDemand from "./VoiceOnDemand";
-import WhereAreYouFromManager from "./WhereAreYouFromManager";
 
 export {
   AdventureGame,

--- a/src/scripts/memberMigration.ts
+++ b/src/scripts/memberMigration.ts
@@ -24,7 +24,7 @@ interface StoredInformation {
   lastMaxUserId: string;
 }
 
-const infoPath = "./unassignedMigration.json";
+const infoPath = "./memberMigration.json";
 
 const loadStoredInformation = async (): Promise<StoredInformation> => {
   return new Promise((res, rej) => {
@@ -46,14 +46,13 @@ const stopScheduling = (reason: string): Promise<void> => {
 
   const guild = bot.guilds.resolve(guildId);
   const output = guild.channels.cache.find((c) => c.name === "bot-output");
-  const engineer = guild.roles.cache.find((r) => r.name === "Server Engineer");
+  const engineer = guild.roles.cache.find((r) => r.name === "Developer");
   const engPing = `<@&${engineer}>`;
 
   if (!(output instanceof TextChannel)) return;
 
-  const disableCommand =
-    "sudo /bin/systemctl disable unassigned-migration.timer";
-  const stopCommand = "sudo /bin/systemctl stop unassigned-migration";
+  const disableCommand = "sudo /bin/systemctl disable member-migration.timer";
+  const stopCommand = "sudo /bin/systemctl stop member-migration";
 
   const failureMessage = `Failed to stop scheduling the migration! Please run the following commands in the cloud instance:
   ${disableCommand}
@@ -159,8 +158,8 @@ const main = async () => {
   const countryRoles = await getCountryRoles(guild);
   console.log(`Loaded ${countryRoles.length} country roles`);
 
-  const unassignedRole = guild.roles.resolve(roleId);
-  if (!unassignedRole) {
+  const memberRole = guild.roles.resolve(roleId);
+  if (!memberRole) {
     throw new Error("Couldn't find role with id " + roleId);
   }
 
@@ -174,8 +173,8 @@ const main = async () => {
       .filter(
         (member) =>
           !member.user.bot &&
-          (member.roles as unknown as string[]).every(
-            (roleId) => !countryRoles.includes(roleId)
+          (member.roles as unknown as string[]).some((roleId) =>
+            countryRoles.includes(roleId)
           )
       )
       .map((member) => member.user.id);


### PR DESCRIPTION
This PR implements support for a new member role. The plan is to move away from an non-member role (currently Unassigned) and instead have a common role for all members of the server who have dropped their flag and selected their region to clean up permissions and make creating new server templates a lot easier.

## Steps taken

- Updated the old unassignedMigration script to do the opposite of its original purpose. When run, it will add the Member role to each member encountered that has a role starting with "I'm from". Other members will remain untouched.

- Updated WhereAreYouFromManager to add the role on flag-drop. Since permissions will eventually be tied to the role, it should only be given out when a region is selected to reflect the current behaviour. Since that equals the desired behaviour for the welcome message, it made sense to fix #147 as well.