### PR TITLE
add lockFileMaintenance so that renovate also updates package-lock

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -9,6 +9,7 @@
   "labels": [
     "renovate"
   ],
+  "lockFileMaintenance": { "enabled": true },
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
add lockFileMaintenance so that renovate also updates package-lock
this is necessary because we have npm ci in the ci pipline