### PR TITLE
fix: group jest packages in renovate

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -21,6 +21,13 @@
         "prisma"
       ],
       "groupName": "prisma packages"
+    },
+    {
+      "matchPackageNames": [
+        "ts-jest",
+        "jest"
+      ],
+      "groupName": "jest packages"
     }
   ]
 }


### PR DESCRIPTION
jest and ts-jest are both attempted to be updated (see #279 and #280 respectively) but require the other to be updated with them.

This PR groups them so renovate updates them together.