### PR TITLE
fix: broken flag overrides and regional roles being assigned

### DIFF
--- a/__tests__/utils/country-role-finder.spec.ts
+++ b/__tests__/utils/country-role-finder.spec.ts
@@ -19,6 +19,7 @@ describe("CountryRoleFinder", () => {
     expect(CountryRoleFinder.isCountryRole("Germany :flag_DE")).toBeFalsy();
     expect(CountryRoleFinder.isCountryRole("Award Winner :eyes:")).toBeFalsy();
     expect(CountryRoleFinder.isCountryRole("Award Winner 🏅")).toBeFalsy();
+    expect(CountryRoleFinder.isCountryRole("USA (Northeast) 🇺🇸")).toBeFalsy();
   });
 
   it("should return the country-name", () => {
@@ -73,6 +74,20 @@ describe("CountryRoleFinder", () => {
       title: "flag for Wales",
     };
     role.name = "the UK 🇬🇧";
+    expect(CountryRoleFinder.isRoleFromCountry(country, role)).toBeTruthy();
+  });
+
+  it("should work with flag emojis that have manual overrides", () => {
+    const mockDiscord = new MockDiscord();
+    const role = mockDiscord.getRole();
+    const country = {
+      code: "EA",
+      emoji: "🇪🇦",
+      unicode: "U+1F1EA U+1F1E6",
+      name: "Spain",
+      title: "flag for Spain",
+    };
+    role.name = "Spain 🇪🇸";
     expect(CountryRoleFinder.isRoleFromCountry(country, role)).toBeTruthy();
   });
 });

--- a/src/programs/where-are-you-from.ts
+++ b/src/programs/where-are-you-from.ts
@@ -47,8 +47,9 @@ const whereAreYouFrom = async (message: Message) => {
       }
       await message.member.roles.add(roleToAssign);
       await message.react("👍");
-      const isCountryWithRegionRole = regionCountries.some((country) =>
-        roleToAssign.name.endsWith(`${country}!`)
+      const isCountryWithRegionRole = regionCountries.some(
+        (countryName) =>
+          CountryRoleFinder.getCountryByRole(roleToAssign.name) === countryName
       );
 
       const rules = message.guild.channels.cache.find(
@@ -66,10 +67,9 @@ const whereAreYouFrom = async (message: Message) => {
       );
 
       if (isCountryWithRegionRole) {
-        const countryFromRoleNameRegex = /.*\s(.*)!$/;
-        const lowerCaseCountry = roleToAssign.name
-          .match(countryFromRoleNameRegex)[1]
-          .toLowerCase();
+        const lowerCaseCountry = CountryRoleFinder.getCountryByRole(
+          roleToAssign.name
+        ).toLowerCase();
         await ghostPing(message, lowerCaseCountry);
       }
     }

--- a/src/utils/country-role-finder.ts
+++ b/src/utils/country-role-finder.ts
@@ -30,9 +30,19 @@ export class CountryRoleFinder {
     return countries.find((country) => this.check(country, input));
   }
 
+  private static emojiOverrides: Record<string, string> = {
+    "🇺🇲": "🇺🇸",
+    "🇨🇵": "🇫🇷",
+    "🇲🇫": "🇫🇷",
+    "🇪🇦": "🇪🇸",
+    "🇮🇴": "🇬🇧",
+  };
+
   private static check(country: FinderCountryProperties, compare: string) {
-    return (
-      compare.includes(country.emoji) || compare === `I'm from ${country.name}!`
-    );
+    if (compare.match(/\(.*\)/)) return false;
+
+    const emoji = this.emojiOverrides[country.emoji] ?? country.emoji;
+
+    return compare.includes(emoji) || compare === `I'm from ${country.name}!`;
   }
 }


### PR DESCRIPTION
This PR closes #306 and reintroduces previously broken flag overrides. They broke since the emojis now also play a relevant role. Thus a small record was introduced to keep overrides of the emojis to resolve the correct role in case lookalike flags (:flag_ea: vs :flag_es: for example) are used.