### PR TITLE
fix/country role related commands

### DIFF
--- a/__tests__/utils/country-role-finder.spec.ts
+++ b/__tests__/utils/country-role-finder.spec.ts
@@ -11,6 +11,12 @@ describe("CountryRoleFinder", () => {
     expect(
       CountryRoleFinder.isCountryRole("I'm from Åland Islands! 🇦🇽")
     ).toBeTruthy();
+
+    expect(CountryRoleFinder.isCountryRole("I'm from the USA!")).toBeTruthy();
+    expect(
+      CountryRoleFinder.isCountryRole("I'm from the USA! (West)", true)
+    ).toBeTruthy();
+    expect(CountryRoleFinder.isCountryRole("USA (West) 🇺🇸", true)).toBeTruthy();
   });
 
   it("should not find as country-role", () => {

--- a/src/programs/birthday-manager.ts
+++ b/src/programs/birthday-manager.ts
@@ -322,9 +322,9 @@ async function fetchUserCountryRoles(
   user: GuildMember
 ): Promise<CountryWithRegion[]> {
   return user.roles.cache
-    .filter((role) => CountryRoleFinder.isCountryRole(role.name))
+    .filter((role) => CountryRoleFinder.isCountryRole(role.name, true))
     .map<CountryWithRegion>((role) => ({
-      country: CountryRoleFinder.getCountryByRole(role.name),
+      country: CountryRoleFinder.getCountryByRole(role.name, true),
       region: role.name.substring(
         role.name.indexOf("(") + 1,
         role.name.indexOf(")")
@@ -336,7 +336,7 @@ function timezonesFromRole(props: CountryWithRegion): readonly string[] {
   const { country, region } = props;
   // Edge cases
   switch (country) {
-    case "the USA":
+    case "USA":
       switch (region) {
         case "Southwest": {
           return ["America/Shiprock", "America/Phoenix"];
@@ -389,7 +389,7 @@ function timezonesFromRole(props: CountryWithRegion): readonly string[] {
             .filter((tz) => tz !== null);
         }
       }
-    case "the UK":
+    case "UK":
       return getCountry("GB").timezones;
     case "Mexico":
       return getCountry("MX")
@@ -441,7 +441,7 @@ function timezonesFromRole(props: CountryWithRegion): readonly string[] {
     case "Chile": {
       return ["America/Santiago"];
     }
-    case "the UAE": {
+    case "UAE": {
       return getCountry("AE").timezones;
     }
     case "Russia": {

--- a/src/programs/profile.ts
+++ b/src/programs/profile.ts
@@ -21,30 +21,25 @@ const profile = async (message: Message) => {
       );
       return;
     }
-    const profileEmbed = await getProfileEmbed(requestedMember, message);
+    const profileEmbed = await getProfileEmbed(requestedMember);
     await message.channel.send(profileEmbed);
   }
 };
 
 const getProfileEmbed = async (
-  member: GuildMember,
-  message: Message
-): Promise<MessageEmbed> => {
+  member: GuildMember
+): Promise<MessageEmbed | string> => {
   const profileEmbed = new MessageEmbed();
-  const countryRole = member.roles.cache.find((role) =>
-    CountryRoleFinder.isCountryRole(role.name)
-  );
-  let countryString = "";
-  member.roles.cache.forEach((role) => {
-    if (CountryRoleFinder.isCountryRole(role.name)) {
-      countryString = countryString + role.name + "\n";
-    }
-  });
+  const countries = member.roles.cache
+    .filter((role) => {
+      return CountryRoleFinder.isCountryRole(role.name, true);
+    })
+    .map(({ name }) => name);
+  const countryString = countries.join("\n");
   const yesEmoji = member.guild.emojis.cache.find((e) => e.name == "yes");
   const birthdayString = formatBirthday(await getUserBirthday(member.user.id));
-  if (!countryRole) {
-    await message.reply("That user isn't registered here!");
-    return null;
+  if (countries.length === 0) {
+    return "That user isn't registered here!";
   }
 
   const memberWithGroups = await prisma.groupMember.findFirst({

--- a/src/programs/where-are-you-from.ts
+++ b/src/programs/where-are-you-from.ts
@@ -135,6 +135,9 @@ export const updateAfterRegionSelect = async (
   oldMember: GuildMember | PartialGuildMember,
   newMember: GuildMember | PartialGuildMember
 ) => {
+  const gainedRole = oldMember.roles.cache.size < newMember.roles.cache.size;
+  if (!gainedRole) return;
+
   const findGeneralRole = (member: GuildMember | PartialGuildMember) =>
     member.roles.cache.find(({ name }) => {
       return regionCountries.some(

--- a/src/utils/country-role-finder.ts
+++ b/src/utils/country-role-finder.ts
@@ -4,8 +4,8 @@ import { Role } from "discord.js";
 type FinderCountryProperties = Pick<Country, "name" | "emoji">;
 
 export class CountryRoleFinder {
-  static getCountryByRole(input: string): string | null {
-    const result = this.getMatches(input);
+  static getCountryByRole(input: string, allowRegions = false): string | null {
+    const result = this.getMatches(input, allowRegions);
     return result?.name;
   }
 

--- a/src/utils/country-role-finder.ts
+++ b/src/utils/country-role-finder.ts
@@ -9,8 +9,8 @@ export class CountryRoleFinder {
     return result?.name;
   }
 
-  static isCountryRole(input: string): boolean {
-    const result = this.getMatches(input);
+  static isCountryRole(input: string, allowRegions = false): boolean {
+    const result = this.getMatches(input, allowRegions);
     return !!result;
   }
 
@@ -26,8 +26,10 @@ export class CountryRoleFinder {
     return this.check(country, role.name);
   }
 
-  private static getMatches(input: string): Country {
-    return countries.find((country) => this.check(country, input));
+  private static getMatches(input: string, allowRegions = false): Country {
+    return countries.find((country) =>
+      this.check(country, input, allowRegions)
+    );
   }
 
   private static emojiOverrides: Record<string, string> = {
@@ -38,11 +40,22 @@ export class CountryRoleFinder {
     "🇮🇴": "🇬🇧",
   };
 
-  private static check(country: FinderCountryProperties, compare: string) {
-    if (compare.match(/\(.*\)/)) return false;
+  private static check(
+    country: FinderCountryProperties,
+    compare: string,
+    allowRegions = false
+  ) {
+    if (!allowRegions && compare.match(/\(.*\)/)) return false;
 
     const emoji = this.emojiOverrides[country.emoji] ?? country.emoji;
 
-    return compare.includes(emoji) || compare === `I'm from ${country.name}!`;
+    const comparator = (a: string, b: string) =>
+      allowRegions ? a.startsWith(b) : a === b;
+
+    return (
+      compare.includes(emoji) ||
+      comparator(compare, `I'm from ${country.name}!`) ||
+      comparator(compare, `I'm from the ${country.name}!`)
+    );
   }
 }


### PR DESCRIPTION
- fix: double pings when selecting region role
- fix: !profile for US members
- fix: timezones by country for !birthday

The double pings were caused by a faulty condition that would trigger in the event where the member gets their general role removed since in that case oldMember has it and newMember has a region role. This was fixed by checking if newMember has more roles than oldMember. This fix has been live through the night and appears to work properly.

!profile was fixed by adding an optional boolean to the CountryRoleFinder that allows regional roles to be picked up which is a requirement for both !profile and !birthday.

In addition to that !birthday contained some manual overrides for `the USA` (amongst others) which now failed as the `the` is not part of the country string anymore.