### PR TITLE
fix: disable group YesTheoryUploads for members

### DIFF
--- a/src/programs/group-manager.ts
+++ b/src/programs/group-manager.ts
@@ -144,6 +144,15 @@ const groupManager = async (message: Message, isConfig: boolean) => {
 
     args.shift();
     const [requestName] = args;
+
+    if (!message.author.bot && !isGroupAllowed(requestName)) {
+      await Tools.handleUserError(
+        message,
+        "That group is not pingable by members, sorry!"
+      );
+      return;
+    }
+
     const groups = await prisma.userGroup.findMany({
       include: {
         userGroupMembersGroupMembers: { include: { groupMember: true } },
@@ -735,6 +744,11 @@ const isChannelAllowed = (channel: Channel): boolean => {
     return true;
 
   return allowedChannels.includes(channel.name);
+};
+
+const isGroupAllowed = (groupName: string) => {
+  const memberDisabledGroups = ["yestheoryuploads"];
+  return !memberDisabledGroups.includes(groupName.toLowerCase());
 };
 
 export default groupManager;


### PR DESCRIPTION
We do not want the YesTheoryUploads group to be pinged by all members, just by the bot (ignoring even supports and admins for now).

Until #320 is closed, a little string comparison shall do the trick.