### PR TITLE
#325 fix: accept feb-29th as birthday

### DIFF
--- a/src/programs/birthday-manager.ts
+++ b/src/programs/birthday-manager.ts
@@ -241,7 +241,7 @@ export function getUserBirthdate(message: string): Date | null {
     return null;
   }
 
-  return new Date(1970, month, day);
+  return new Date(1972, month, day);
 }
 
 async function getUserTimezone(message: Message): Promise<string> {


### PR DESCRIPTION
The bot previously used the year 1970 to return the date so feb 29th automatically rolled over to march 1st. Instead we can use year 1972 which was a leapyear to return and save the date.