### PR TITLE
feat: Add GuildMemberUpdate to event distribution

### DIFF
--- a/__tests__/event-distribution/events/__snapshots__/guild-member-update.spec.ts.snap
+++ b/__tests__/event-distribution/events/__snapshots__/guild-member-update.spec.ts.snap
@@ -1,0 +1,141 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GuildMemberUpdates should add data to the tree 1`] = `
+Object {
+  "added": Object {
+    "Test": Array [
+      Object {
+        "ioc": Object {},
+        "options": Object {
+          "event": "GUILD_MEMBER_UPDATE",
+          "roleNamesAdded": Array [
+            "Test",
+          ],
+          "roleNamesRemoved": Array [
+            "Example",
+          ],
+        },
+      },
+    ],
+  },
+  "removed": Object {
+    "Example": Array [
+      Object {
+        "ioc": Object {},
+        "options": Object {
+          "event": "GUILD_MEMBER_UPDATE",
+          "roleNamesAdded": Array [
+            "Test",
+          ],
+          "roleNamesRemoved": Array [
+            "Example",
+          ],
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`GuildMemberUpdates should add data to the tree 2`] = `
+Object {
+  "": Object {
+    "": Array [
+      Object {
+        "ioc": Object {},
+        "options": Object {
+          "event": "GUILD_MEMBER_UPDATE",
+        },
+      },
+    ],
+  },
+  "added": Object {
+    "Test": Array [
+      Object {
+        "ioc": Object {},
+        "options": Object {
+          "event": "GUILD_MEMBER_UPDATE",
+          "roleNamesAdded": Array [
+            "Test",
+          ],
+          "roleNamesRemoved": Array [
+            "Example",
+          ],
+        },
+      },
+    ],
+  },
+  "removed": Object {
+    "Example": Array [
+      Object {
+        "ioc": Object {},
+        "options": Object {
+          "event": "GUILD_MEMBER_UPDATE",
+          "roleNamesAdded": Array [
+            "Test",
+          ],
+          "roleNamesRemoved": Array [
+            "Example",
+          ],
+        },
+      },
+    ],
+  },
+}
+`;
+
+exports[`GuildMemberUpdates should add data to the tree 3`] = `
+Object {
+  "": Object {
+    "": Array [
+      Object {
+        "ioc": Object {},
+        "options": Object {
+          "event": "GUILD_MEMBER_UPDATE",
+        },
+      },
+    ],
+  },
+  "added": Object {
+    "Test": Array [
+      Object {
+        "ioc": Object {},
+        "options": Object {
+          "event": "GUILD_MEMBER_UPDATE",
+          "roleNamesAdded": Array [
+            "Test",
+          ],
+          "roleNamesRemoved": Array [
+            "Example",
+          ],
+        },
+      },
+      Object {
+        "ioc": Object {},
+        "options": Object {
+          "event": "GUILD_MEMBER_UPDATE",
+          "roleNamesAdded": Array [
+            "Test",
+          ],
+        },
+      },
+    ],
+  },
+  "removed": Object {
+    "Example": Array [
+      Object {
+        "ioc": Object {},
+        "options": Object {
+          "event": "GUILD_MEMBER_UPDATE",
+          "roleNamesAdded": Array [
+            "Test",
+          ],
+          "roleNamesRemoved": Array [
+            "Example",
+          ],
+        },
+      },
+    ],
+  },
+}
+`;

--- a/__tests__/event-distribution/events/guild-member-update.spec.ts
+++ b/__tests__/event-distribution/events/guild-member-update.spec.ts
@@ -1,0 +1,74 @@
+import {
+  addGuildMemberUpdateHandler,
+  extractGuildMemberUpdateInfo,
+  GuildMemberUpdateEventHandlerOptions,
+} from "../../../src/event-distribution/events/guild-member-update";
+import MockDiscord from "../../mocks";
+import {
+  InstanceOrConstructor,
+  StringIndexedHIOCTree,
+} from "../../../src/event-distribution/types/hioc";
+import { CommandHandler, DiscordEvent } from "../../../src/event-distribution";
+
+describe("GuildMemberUpdates", () => {
+  let mockDiscord: MockDiscord;
+  beforeEach(() => {
+    mockDiscord = new MockDiscord();
+  });
+
+  // it("should extract keys despite no role differences", () => {
+  //   const oldMember = mockDiscord.getGuildMember();
+  //   const newMember = mockDiscord.getGuildMember();
+  //   newMember.nickname = "Test";
+  //   const result = extractGuildMemberUpdateInfo(oldMember, newMember);
+  //   expect(result).toMatchSnapshot();
+  // });
+  //
+  // it("should extract keys with a single role difference", () => {
+  //   const oldMember = mockDiscord.getGuildMember();
+  //   const newMember = mockDiscord.getGuildMember();
+  //   const role = mockDiscord.getRole();
+  //   newMember.roles.cache.set(role.id, role);
+  //   const result = extractGuildMemberUpdateInfo(oldMember, newMember);
+  //   expect(result).toMatchSnapshot();
+  // });
+  //
+  // it("should extract keys with multiple role differences", () => {
+  //   const oldMember = mockDiscord.getGuildMember();
+  //   const newMember = mockDiscord.getGuildMember();
+  //   const role = mockDiscord.getRole();
+  //   const role2 = mockDiscord.getRole();
+  //   newMember.roles.cache.set(role.id, role);
+  //   newMember.roles.cache.set(role2.id, role2);
+  //   const result = extractGuildMemberUpdateInfo(oldMember, newMember);
+  //   expect(result).toMatchSnapshot();
+  // });
+
+  it("should add data to the tree", () => {
+    const tree: StringIndexedHIOCTree<DiscordEvent.GUILD_MEMBER_UPDATE> = {};
+    const options: GuildMemberUpdateEventHandlerOptions = {
+      event: DiscordEvent.GUILD_MEMBER_UPDATE,
+      roleNamesAdded: ["Test"],
+      roleNamesRemoved: ["Example"],
+    };
+    const ioc = {} as InstanceOrConstructor<
+      CommandHandler<DiscordEvent.GUILD_MEMBER_UPDATE>
+    >;
+
+    addGuildMemberUpdateHandler(options, ioc, tree);
+    expect(tree).toMatchSnapshot();
+
+    const secondOptions: GuildMemberUpdateEventHandlerOptions = {
+      event: DiscordEvent.GUILD_MEMBER_UPDATE,
+    };
+    addGuildMemberUpdateHandler(secondOptions, ioc, tree);
+    expect(tree).toMatchSnapshot();
+
+    const thirdOptions: GuildMemberUpdateEventHandlerOptions = {
+      event: DiscordEvent.GUILD_MEMBER_UPDATE,
+      roleNamesAdded: ["Test"],
+    };
+    addGuildMemberUpdateHandler(thirdOptions, ioc, tree);
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/event-distribution/README.md
+++ b/src/event-distribution/README.md
@@ -85,3 +85,29 @@ options and generic argument for the `CommandHandler`;
 ##### Arguments
 
 The handler function is called with the Discord.JS `MessageReaction` and `User` objects received as event.
+
+### Guild Member Update
+
+The bot receives an event when a guild member is updated. That includes role changes and nickname changes for example.
+
+#### Options
+
+The following options are available:
+
+```ts
+interface GuildMemberUpdateEventHandlerOptions {
+  event: DiscordEvent.GUILD_MEMBER_UPDATE;
+  roleNamesAdded?: string[]; // When any of these roles are added, the handler is called
+  roleNamesRemoved?: string[]; // When any of these roles are removed, the handler is called
+}
+```
+
+#### Enum
+
+Use `DiscordEvent.GUILD_MEMBER_UPDATE` as event in the decorator's options and generic argument for the `CommandHandler`.
+
+#### Arguments
+
+The handler function is called with two `GuildMember | PartialGuildMember` objects, the first representing the member before the change, the second after the change.
+
+

--- a/src/event-distribution/command-decorator.ts
+++ b/src/event-distribution/command-decorator.ts
@@ -1,5 +1,5 @@
 import { EventHandlerOptions } from "./events/events";
-import { EventLocation } from "./types/base";
+import { BaseOptions, DiscordEvent, EventLocation } from "./types/base";
 import { HandlerClass } from "./types/handler";
 import distribution from "./index";
 import { createYesBotLogger } from "../log";
@@ -9,34 +9,58 @@ const explanation =
   "Commands that require roles or channel names won't work in DMs since the roles cannot be read from DM events.";
 
 export const Command = <T extends EventHandlerOptions>(options: T) => {
-  const channels = options.channelNames ?? [];
-  const roles = options.requiredRoles ?? [];
-  const requiresServer = channels.length > 0 || roles.length > 0;
+  // TODO this needs a neater way of doing things...
+  if (options.event !== DiscordEvent.GUILD_MEMBER_UPDATE) {
+    const channels = options.channelNames ?? [];
+    const roles = options.requiredRoles ?? [];
+    const requiresServer = channels.length > 0 || roles.length > 0;
 
-  if (!options.location) {
-    options.location = requiresServer
-      ? EventLocation.SERVER
-      : EventLocation.ANYWHERE;
+    if (!options.location) {
+      options.location = requiresServer
+        ? EventLocation.SERVER
+        : EventLocation.ANYWHERE;
+    }
   }
 
   return <U extends HandlerClass<T["event"]>>(target: U) => {
     const commandClassName = target.name;
     logger.debug(`Loading new command: ${target.name}`);
 
-    if (requiresServer && options.location === EventLocation.DIRECT_MESSAGE) {
+    // TODO a much neater way.
+    if (options.event !== DiscordEvent.GUILD_MEMBER_UPDATE) {
+      checkBaseOptions(options, commandClassName);
+    }
+
+    try {
+      distribution.addWithOptions(options, target);
+    } catch (e) {
       logger.error(
-        `Failed to load command ${commandClassName}! The command requires roles or channel names but was set to location ${EventLocation.DIRECT_MESSAGE}. ${explanation}`
-      );
-      return;
-    }
-
-    if (requiresServer && options.location === EventLocation.ANYWHERE) {
-      logger.warn(
-        `Adding command ${commandClassName} with required roles or limited channels which was set to location ${EventLocation.ANYWHERE}. ${explanation}`
+        `Failed to load command ${commandClassName}! Error was: `,
+        e instanceof Error ? { error: e.message } : e
       );
     }
-
-    distribution.addWithOptions(options, target);
     return target;
   };
+};
+
+const baseOptionsRequireServer = (options: BaseOptions) => {
+  const channels = options.channelNames ?? [];
+  const roles = options.requiredRoles ?? [];
+  return channels.length > 0 || roles.length > 0;
+};
+
+const checkBaseOptions = (options: BaseOptions, commandClassName: string) => {
+  const requiresServer = baseOptionsRequireServer(options);
+  if (requiresServer && options.location === EventLocation.DIRECT_MESSAGE) {
+    logger.error(
+      `Failed to load command ${commandClassName}! The command requires roles or channel names but was set to location ${EventLocation.DIRECT_MESSAGE}. ${explanation}`
+    );
+    return;
+  }
+
+  if (requiresServer && options.location === EventLocation.ANYWHERE) {
+    logger.warn(
+      `Adding command ${commandClassName} with required roles or limited channels which was set to location ${EventLocation.ANYWHERE}. ${explanation}`
+    );
+  }
 };

--- a/src/event-distribution/command-decorator.ts
+++ b/src/event-distribution/command-decorator.ts
@@ -9,24 +9,14 @@ const explanation =
   "Commands that require roles or channel names won't work in DMs since the roles cannot be read from DM events.";
 
 export const Command = <T extends EventHandlerOptions>(options: T) => {
-  // TODO this needs a neater way of doing things...
   if (options.event !== DiscordEvent.GUILD_MEMBER_UPDATE) {
-    const channels = options.channelNames ?? [];
-    const roles = options.requiredRoles ?? [];
-    const requiresServer = channels.length > 0 || roles.length > 0;
-
-    if (!options.location) {
-      options.location = requiresServer
-        ? EventLocation.SERVER
-        : EventLocation.ANYWHERE;
-    }
+    setDefaultOnBaseOptions(options);
   }
 
   return <U extends HandlerClass<T["event"]>>(target: U) => {
     const commandClassName = target.name;
     logger.debug(`Loading new command: ${target.name}`);
 
-    // TODO a much neater way.
     if (options.event !== DiscordEvent.GUILD_MEMBER_UPDATE) {
       checkBaseOptions(options, commandClassName);
     }
@@ -47,6 +37,14 @@ const baseOptionsRequireServer = (options: BaseOptions) => {
   const channels = options.channelNames ?? [];
   const roles = options.requiredRoles ?? [];
   return channels.length > 0 || roles.length > 0;
+};
+
+const setDefaultOnBaseOptions = (options: BaseOptions) => {
+  if (!options.location) {
+    options.location = baseOptionsRequireServer(options)
+      ? EventLocation.SERVER
+      : EventLocation.ANYWHERE;
+  }
 };
 
 const checkBaseOptions = (options: BaseOptions, commandClassName: string) => {

--- a/src/event-distribution/events/events.ts
+++ b/src/event-distribution/events/events.ts
@@ -17,14 +17,23 @@ import {
 } from "./reactions";
 import { StringIndexedHIOCTree } from "../types/hioc";
 import { Message, MessageReaction, User } from "discord.js";
+import {
+  addGuildMemberUpdateHandler,
+  extractGuildMemberUpdateInfo,
+  GuildMemberUpdateArgument,
+  GuildMemberUpdateEventHandlerOptions,
+  GuildMemberUpdateHandlerFunction,
+} from "./guild-member-update";
 
 export type EventHandlerOptions =
   | MessageEventHandlerOptions
-  | ReactionEventHandlerOptions;
+  | ReactionEventHandlerOptions
+  | GuildMemberUpdateEventHandlerOptions;
 
 export type HandlerFunction<T extends DiscordEvent> =
   | MessageHandlerFunction<T>
-  | ReactionHandlerFunction<T>;
+  | ReactionHandlerFunction<T>
+  | GuildMemberUpdateHandlerFunction<T>;
 
 export const addEventHandler: AddEventHandlerFunction<EventHandlerOptions> = (
   options,
@@ -47,6 +56,12 @@ export const addEventHandler: AddEventHandlerFunction<EventHandlerOptions> = (
           DiscordEvent.REACTION_ADD | DiscordEvent.REACTION_REMOVE
         >
       );
+    case DiscordEvent.GUILD_MEMBER_UPDATE:
+      return addGuildMemberUpdateHandler(
+        options,
+        ioc,
+        tree as StringIndexedHIOCTree<DiscordEvent.GUILD_MEMBER_UPDATE>
+      );
   }
 };
 
@@ -54,13 +69,23 @@ export const extractEventInfo: ExtractInfoFunction<DiscordEvent> = (
   event,
   ...args
 ) => {
-  switch (event) {
-    case DiscordEvent.MESSAGE:
-      return extractMessageInfo(args[0] as Message);
-    case DiscordEvent.REACTION_ADD:
-    case DiscordEvent.REACTION_REMOVE:
-      return extractReactionInfo(args[0] as MessageReaction, args[1] as User);
-    default:
-      throw new Error("Could not extract info for event " + event);
-  }
+  const getInfos = () => {
+    switch (event) {
+      case DiscordEvent.MESSAGE:
+        return extractMessageInfo(args[0] as Message);
+      case DiscordEvent.REACTION_ADD:
+      case DiscordEvent.REACTION_REMOVE:
+        return extractReactionInfo(args[0] as MessageReaction, args[1] as User);
+      case DiscordEvent.GUILD_MEMBER_UPDATE:
+        return extractGuildMemberUpdateInfo(
+          args[0] as GuildMemberUpdateArgument,
+          args[1] as GuildMemberUpdateArgument
+        );
+      default:
+        throw new Error("Could not extract info for event " + event);
+    }
+  };
+  const infos = getInfos();
+
+  return Array.isArray(infos) ? infos : [infos];
 };

--- a/src/event-distribution/events/guild-member-update.ts
+++ b/src/event-distribution/events/guild-member-update.ts
@@ -1,0 +1,128 @@
+import {
+  AddEventHandlerFunction,
+  DiscordEvent,
+  ExtractInfoForEventFunction,
+  HandlerFunctionFor,
+} from "../types/base";
+import {
+  Collection,
+  GuildMember,
+  PartialGuildMember,
+  Role,
+  Snowflake,
+} from "discord.js";
+import { HIOC, StringIndexedHIOCTree } from "../types/hioc";
+
+export interface GuildMemberUpdateEventHandlerOptions {
+  event: DiscordEvent.GUILD_MEMBER_UPDATE;
+  stateful?: false;
+  roleNamesAdded?: string[];
+  roleNamesRemoved?: string[];
+}
+
+export type GuildMemberUpdateArgument = GuildMember | PartialGuildMember;
+
+export type GuildMemberUpdateHandlerFunction<T extends DiscordEvent> =
+  HandlerFunctionFor<
+    T,
+    DiscordEvent.GUILD_MEMBER_UPDATE,
+    [GuildMemberUpdateArgument, GuildMemberUpdateArgument]
+  >;
+
+const addedRoleKey = "added";
+const removedRoleKey = "removed";
+
+export const addGuildMemberUpdateHandler: AddEventHandlerFunction<GuildMemberUpdateEventHandlerOptions> =
+  (options, ioc, tree) => {
+    const {
+      roleNamesAdded,
+      roleNamesRemoved,
+    }: GuildMemberUpdateEventHandlerOptions = {
+      roleNamesAdded: [],
+      roleNamesRemoved: [],
+      ...options,
+    };
+
+    const addedLength = roleNamesAdded.length;
+    const removedLength = roleNamesRemoved.length;
+
+    const isGeneralHandler = addedLength === 0 && removedLength === 0;
+    if (isGeneralHandler) {
+      addRoleHandlersToTree(tree, "", [""], { ioc, options });
+      return;
+    }
+
+    addRoleHandlersToTree(tree, addedRoleKey, roleNamesAdded, { ioc, options });
+    addRoleHandlersToTree(tree, removedRoleKey, roleNamesRemoved, {
+      ioc,
+      options,
+    });
+  };
+
+const addRoleHandlersToTree = (
+  tree: StringIndexedHIOCTree<DiscordEvent.GUILD_MEMBER_UPDATE>,
+  firstKey: typeof addedRoleKey | typeof removedRoleKey | "",
+  secondKeys: string[],
+  hioc: HIOC<DiscordEvent.GUILD_MEMBER_UPDATE>
+) => {
+  tree[firstKey] ??= {};
+  const subTree = tree[
+    firstKey
+  ] as StringIndexedHIOCTree<DiscordEvent.GUILD_MEMBER_UPDATE>;
+
+  for (const secondKey of secondKeys) {
+    subTree[secondKey] ??= [];
+    const handlers = subTree[
+      secondKey
+    ] as HIOC<DiscordEvent.GUILD_MEMBER_UPDATE>[];
+    handlers.push(hioc);
+  }
+};
+
+export const extractGuildMemberUpdateInfo: ExtractInfoForEventFunction<DiscordEvent.GUILD_MEMBER_UPDATE> =
+  (oldMember, newMember) => {
+    const oldRoles = oldMember.roles.cache;
+    const oldRolesLength = oldRoles.size;
+    const newRoles = newMember.roles.cache;
+    const newRolesLength = newRoles.size;
+
+    if (oldRolesLength === newRolesLength) {
+      return {
+        member: newMember,
+        isDirectMessage: false,
+        handlerKeys: ["", ""],
+      };
+    }
+
+    const firstKey =
+      oldRolesLength > newRolesLength ? removedRoleKey : addedRoleKey;
+
+    const diff = getRoleDiff(oldRoles, newRoles);
+
+    const toInfos = (roleChange: Role) => {
+      return {
+        handlerKeys: [firstKey, roleChange.name],
+        member: newMember,
+        isDirectMessage: false,
+      };
+    };
+
+    return [...diff.added.map(toInfos), ...diff.removed.map(toInfos)];
+  };
+
+const getRoleDiff = (
+  oldRoles: Collection<Snowflake, Role>,
+  newRoles: Collection<Snowflake, Role>
+): { added: Role[]; removed: Role[] } => {
+  const oldIds = oldRoles.map(({ id }) => id);
+  const newIds = newRoles.map(({ id }) => id);
+
+  const added = newIds
+    .filter((id) => !oldIds.includes(id))
+    .map((id) => newRoles.get(id));
+  const removed = oldIds
+    .filter((id) => !newIds.includes(id))
+    .map((id) => oldRoles.get(id));
+
+  return { added, removed };
+};

--- a/src/event-distribution/types/base.ts
+++ b/src/event-distribution/types/base.ts
@@ -1,5 +1,5 @@
 import { EventHandlerOptions, HandlerFunction } from "../events/events";
-import { GuildMember } from "discord.js";
+import { GuildMember, PartialGuildMember } from "discord.js";
 import { CommandHandler } from "./handler";
 import { InstanceOrConstructor, StringIndexedHIOCTree } from "./hioc";
 
@@ -7,6 +7,7 @@ export const enum DiscordEvent {
   MESSAGE = "MESSAGE",
   REACTION_ADD = "REACTION_ADD",
   REACTION_REMOVE = "REACTION_REMOVE",
+  GUILD_MEMBER_UPDATE = "GUILD_MEMBER_UPDATE",
 }
 
 export const enum EventLocation {
@@ -36,18 +37,18 @@ export type HandlerFunctionFor<
 
 export interface HandlerInfo {
   handlerKeys: string[];
-  member?: GuildMember;
+  member?: GuildMember | PartialGuildMember;
   isDirectMessage: boolean;
 }
 
 export type ExtractInfoFunction<T extends DiscordEvent> = (
   event: T,
   ...args: Parameters<HandlerFunction<T>>
-) => HandlerInfo;
+) => HandlerInfo[];
 
 export type ExtractInfoForEventFunction<T extends DiscordEvent> = (
   ...args: Parameters<HandlerFunction<T>>
-) => HandlerInfo;
+) => HandlerInfo | HandlerInfo[];
 
 export type AddEventHandlerFunction<T extends EventHandlerOptions> = (
   options: T,

--- a/src/event-distribution/util.ts
+++ b/src/event-distribution/util.ts
@@ -1,0 +1,6 @@
+import { InstanceOrConstructor } from "./types/hioc";
+import { DiscordEvent } from "./types/base";
+
+const getIocName = (ioc: InstanceOrConstructor<DiscordEvent>) => {
+  return typeof ioc === "function" ? ioc.name : ioc.constructor.name;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,10 +36,17 @@ bot.on("guildMemberRemove", (member: GuildMember | PartialGuildMember) =>
 );
 bot.on(
   "guildMemberUpdate",
-  (
+  async (
     oldMember: GuildMember | PartialGuildMember,
     newMember: GuildMember | PartialGuildMember
-  ) => guildMemberUpdate(oldMember, newMember)
+  ) => {
+    await guildMemberUpdate(oldMember, newMember);
+    distribution.handleEvent(
+      DiscordEvent.GUILD_MEMBER_UPDATE,
+      oldMember,
+      newMember
+    );
+  }
 );
 bot.on("message", async (msg: Message) => {
   await messageManager(msg);

--- a/src/programs/decorator-test.ts
+++ b/src/programs/decorator-test.ts
@@ -1,10 +1,11 @@
-import { Message } from "discord.js";
+import { Message, MessageReaction, User } from "discord.js";
 import {
   Command,
   CommandHandler,
   DiscordEvent,
   EventLocation,
 } from "../event-distribution";
+import { GuildMemberUpdateArgument } from "../event-distribution/events/guild-member-update";
 
 /**
  * Example of a stateless message handler (stateful: true missing in config).
@@ -64,5 +65,39 @@ export class DecoratorTest3 extends CommandHandler<DiscordEvent.MESSAGE> {
   handle(message: Message): void {
     ++this.called;
     console.log(`Called handler 3 ${this.called} times`);
+  }
+}
+
+/**
+ * Example of a ReactionAdd Handler.
+ */
+@Command({
+  event: DiscordEvent.REACTION_ADD,
+  description: "What gives?",
+  stateful: false,
+  emoji: "🤓",
+  channelNames: ["bot-output"],
+})
+export class DecoratorTest4 extends CommandHandler<DiscordEvent.REACTION_ADD> {
+  handle(reaction: MessageReaction, user: User): void {
+    console.log(`Called handler 4`);
+  }
+}
+
+/**
+ * Example of a MemberUpdate Handler
+ */
+@Command({
+  event: DiscordEvent.GUILD_MEMBER_UPDATE,
+  description: "Weee",
+  roleNamesAdded: ["Yes Theory"],
+  roleNamesRemoved: ["Seek Discomfort"],
+})
+export class DecoratorTest5 extends CommandHandler<DiscordEvent.GUILD_MEMBER_UPDATE> {
+  handle(
+    oldMember: GuildMemberUpdateArgument,
+    newMember: GuildMemberUpdateArgument
+  ): void {
+    console.log(`Called handler 5`);
   }
 }


### PR DESCRIPTION
This PR adds support for the GuildMemberUpdate event to the new event distribution system.

## Remarks

I have absolutely no idea how to get sensible tests to work. My attempts are commented out in `__tests__/event-distribution/events/guild-member-update.spec.ts` but all failed due to some weird stuff inside Discord.JS (pretty much all interactions with roles and GuildMembers rely on accessing the member's roles which in turn requires accessing the everyone role of the guild). I don't know how to mock that, unfortunately; help is appreciated!