### PR TITLE
fixed yestheoryuploaded ping

### DIFF
--- a/src/programs/yestheory-content.ts
+++ b/src/programs/yestheory-content.ts
@@ -1,25 +1,21 @@
 import Discord, { Message, TextChannel } from "discord.js";
 import { ChatNames } from "../collections/chat-names";
-import { hasRole } from "../common/moderator";
 
 //keep in mind this is very temporarily basic code, until we have the new events up and ready
 const YesTheoryUploadedPing = async (message: Message) => {
-  const user = message.author.id;
-  const MemberGuild = await message.guild.members.fetch(user);
-  if (hasRole(MemberGuild, "Support")) {
-    return;
+  if (message.author.bot) {
+    const channelDiscussion = message.guild.channels.cache.find(
+      (channel) => channel.name === ChatNames.YESTHEORY_DISCUSSION.toString()
+    ) as TextChannel;
+    const embed = new Discord.MessageEmbed()
+      .setColor("BLUE")
+      .setTitle("YesTheory Uploaded!")
+      .setDescription(
+        `Yes Theory posted a new video! Go check it out in ${message.channel.toString()} and talk about it here`
+      );
+    await channelDiscussion.send("@group YesTheoryUploads");
+    await channelDiscussion.send(embed);
   }
-  const channelDiscussion = message.guild.channels.cache.find(
-    (channel) => channel.name === ChatNames.YESTHEORY_DISCUSSION.toString()
-  ) as TextChannel;
-  const embed = new Discord.MessageEmbed()
-    .setColor("BLUE")
-    .setTitle("YesTheory Uploaded!")
-    .setDescription(
-      `Yes Theory posted a new video! Go check it out in ${message.channel.toString()} and talk about it here`
-    );
-  await channelDiscussion.send("@group YesTheoryUploads");
-  await channelDiscussion.send(embed);
 };
 
 export default YesTheoryUploadedPing;

--- a/src/programs/yestheory-content.ts
+++ b/src/programs/yestheory-content.ts
@@ -3,7 +3,7 @@ import { ChatNames } from "../collections/chat-names";
 
 //keep in mind this is very temporarily basic code, until we have the new events up and ready
 const YesTheoryUploadedPing = async (message: Message) => {
-  if (message.author.bot) {
+  if (message.webhookID) {
     const channelDiscussion = message.guild.channels.cache.find(
       (channel) => channel.name === ChatNames.YESTHEORY_DISCUSSION.toString()
     ) as TextChannel;

--- a/src/programs/yestheory-content.ts
+++ b/src/programs/yestheory-content.ts
@@ -3,19 +3,21 @@ import { ChatNames } from "../collections/chat-names";
 
 //keep in mind this is very temporarily basic code, until we have the new events up and ready
 const YesTheoryUploadedPing = async (message: Message) => {
-  if (message.webhookID) {
-    const channelDiscussion = message.guild.channels.cache.find(
-      (channel) => channel.name === ChatNames.YESTHEORY_DISCUSSION.toString()
-    ) as TextChannel;
-    const embed = new Discord.MessageEmbed()
-      .setColor("BLUE")
-      .setTitle("YesTheory Uploaded!")
-      .setDescription(
-        `Yes Theory posted a new video! Go check it out in ${message.channel.toString()} and talk about it here`
-      );
-    await channelDiscussion.send("@group YesTheoryUploads");
-    await channelDiscussion.send(embed);
+  if (!message.webhookID) {
+    return;
   }
+
+  const channelDiscussion = message.guild.channels.cache.find(
+    (channel) => channel.name === ChatNames.YESTHEORY_DISCUSSION.toString()
+  ) as TextChannel;
+  const embed = new Discord.MessageEmbed()
+    .setColor("BLUE")
+    .setTitle("YesTheory Uploaded!")
+    .setDescription(
+      `Yes Theory posted a new video! Go check it out in ${message.channel.toString()} and talk about it here`
+    );
+  await channelDiscussion.send("@group YesTheoryUploads");
+  await channelDiscussion.send(embed);
 };
 
 export default YesTheoryUploadedPing;


### PR DESCRIPTION
If webhooks count as bots this should not return an error and we should no longer need to use `hasRole`.
Used the test YesBot by forcing it to send a message in #yestheory-uploaded which pinged the group.