### PR TITLE
fix: disables DM functionalities due to bot quarantine

### DIFF
--- a/src/programs/map.ts
+++ b/src/programs/map.ts
@@ -11,6 +11,11 @@ export const map = async (message: Message) => {
 };
 
 export const mapAdd = async (message: Message) => {
+  await message.reply(
+    "Hey, unfortunately this command is disabled at the moment as the bot currently isn't allowed to send DMs. This is being worked on :) Make sure to check #updates regularly to see when it's working again. Sorry about the inconveniences!"
+  );
+  return;
+
   const split = message.content.split(" ");
   split.shift();
   const city = split.join(" ");

--- a/src/programs/where-are-you-from.ts
+++ b/src/programs/where-are-you-from.ts
@@ -29,7 +29,7 @@ const whereAreYouFrom = async (message: Message) => {
     const countryToAssign = matchedCountries[0];
     if (countryToAssign) {
       const roleToAssign = getRoleForCountry(countryToAssign, message.guild);
-      const memberDm = await message.author.createDM();
+      // const memberDm = await message.author.createDM();
 
       if (!roleToAssign) {
         const moderatorRole = message.guild.roles.cache.find(
@@ -62,9 +62,9 @@ const whereAreYouFrom = async (message: Message) => {
       if (!isCountryWithRegionRole) {
         await welcomeMember(message.member.user, message.member.guild);
       }
-      await memberDm.send(
-        `Hey! My name is YesBot, I'm so happy to see you've made it into our world, we really hope you stick around!\n\nIn the meantime, you should checkout ${rules.toString()} and ${generalInfo.toString()} , they contain a lot of good-to-knows about our server and what cool stuff you can do.\nIf you'd like me to change your name on the server for you, just message me \`!menu\` and I will help you out! Then I can introduce you to our family :grin:\n\nI know Discord can be a lot to take in at first, trust me, but it's really quite a wonderful place.`
-      );
+      // await memberDm.send(
+      //   `Hey! My name is YesBot, I'm so happy to see you've made it into our world, we really hope you stick around!\n\nIn the meantime, you should checkout ${rules.toString()} and ${generalInfo.toString()} , they contain a lot of good-to-knows about our server and what cool stuff you can do.\nIf you'd like me to change your name on the server for you, just message me \`!menu\` and I will help you out! Then I can introduce you to our family :grin:\n\nI know Discord can be a lot to take in at first, trust me, but it's really quite a wonderful place.`
+      // );
 
       if (isCountryWithRegionRole) {
         const lowerCaseCountry = CountryRoleFinder.getCountryByRole(


### PR DESCRIPTION
This PR disables !mapadd and removes the DM sent in where-are-you-from as reaction to the bot quarantine. These two changes had previously only been on the server and never ended up in the codebase so this should be fixed now that the bot is deployed through docker.