### PR TITLE
Fix: Lock users with timeout role from country channels

### DIFF
--- a/src/events/guild-member-update.ts
+++ b/src/events/guild-member-update.ts
@@ -31,7 +31,15 @@ const guildMemberUpdate = async (
     lockCountryChannels(newMember);
   }
 
+  if (gainedRole(oldMember, newMember, "Time Out")) {
+    lockCountryChannels(newMember);
+  }
+
   if (lostRole(oldMember, newMember, "Break")) {
+    unlockCountryChannels(newMember);
+  }
+
+  if (lostRole(oldMember, newMember, "Time Out")) {
     unlockCountryChannels(newMember);
   }
 


### PR DESCRIPTION
This won't fix issue #369 since it seems to be server permission issues but should fix it to lock users with the `Time Out` role out of country channels