### PR TITLE
fix: reject the loading promise on glob error

### DIFF
--- a/src/event-distribution/event-distribution.ts
+++ b/src/event-distribution/event-distribution.ts
@@ -76,6 +76,7 @@ export class EventDistribution {
       glob(`${directory}/programs/**/*${extension}`, async (e, matches) => {
         if (e) {
           logger.error("Error loading commands: ", e);
+          rej(e);
           return;
         }
 

--- a/src/event-distribution/event-distribution.ts
+++ b/src/event-distribution/event-distribution.ts
@@ -95,6 +95,7 @@ export class EventDistribution {
         } catch (e) {
           logger.error("Error loading commands: ", e);
           rej(e);
+          return;
         }
         logger.debug("Loading complete!");
         res();


### PR DESCRIPTION
There is a case where the initialize promise is neither resolved nor rejected. This PR fixes that.