### PR TITLE
Specify the ordering of database select for release notes

### DIFF
--- a/src/programs/release-notes/usecase/github-release-notes.usecase.ts
+++ b/src/programs/release-notes/usecase/github-release-notes.usecase.ts
@@ -23,6 +23,7 @@ export class GithubReleaseNotesUsecase {
       await this.fetchLatestReleasesFormGitHub();
     const latestRelease = await prisma.release.findFirst({
       where: { releaseTime: newRelease.node.publishedAt },
+      orderBy: { releaseTime: "desc" },
     });
     let tagMessage = !!newRelease.node.description
       ? newRelease.node.description


### PR DESCRIPTION
Just to be sure it works as expected, in case a library would decide to change its default ordering, or the table would, or anything else.