### PR TITLE
Fix: detect multiple flags

### DIFF
--- a/__tests__/utils/country-role-finder.spec.ts
+++ b/__tests__/utils/country-role-finder.spec.ts
@@ -111,6 +111,9 @@ describe("CountryRoleFinder", () => {
       ["🇦🇽 Finland", ["Finland"]],
       ["🇮🇳 🇮🇳 🇮🇳 🇮🇳", ["India"]],
       ["🇮🇳🇮🇳🇮🇳", ["India"]],
+      ["🏴󠁧󠁢󠁷󠁬󠁳󠁿🇮🇳", ["India", "Wales"]],
+      ["🇮🇳🇳🇮", ["India", "Nicaragua"]],
+      ["🏴󠁧󠁢󠁷󠁬󠁳󠁿🇮🇳🇳🇮 Finland", ["Finland", "India", "Nicaragua", "Wales"]],
     ];
 
     for (const [input, expected] of cases) {

--- a/__tests__/utils/country-role-finder.spec.ts
+++ b/__tests__/utils/country-role-finder.spec.ts
@@ -110,7 +110,7 @@ describe("CountryRoleFinder", () => {
       ["🏴󠁧󠁢󠁷󠁬󠁳󠁿", ["Wales"]],
       ["🇦🇽 Finland", ["Finland"]],
       ["🇮🇳 🇮🇳 🇮🇳 🇮🇳", ["India"]],
-      // ["🇮🇳🇮🇳🇮🇳", ["India"]], TODO fix this (https://github.com/Yes-Theory-Fam/yesbot-ts/issues/382
+      ["🇮🇳🇮🇳🇮🇳", ["India"]],
     ];
 
     for (const [input, expected] of cases) {

--- a/src/programs/where-are-you-from.ts
+++ b/src/programs/where-are-you-from.ts
@@ -21,7 +21,9 @@ const whereAreYouFrom = async (message: Message) => {
     );
 
     if (matchedCountries.length === 0) {
-      await message.reply("You must send the flag of the country you are in!");
+      await message.reply(
+        "You must send the flag or name of the country you are in!"
+      );
       return;
     }
 

--- a/src/programs/where-are-you-from.ts
+++ b/src/programs/where-are-you-from.ts
@@ -20,7 +20,7 @@ const whereAreYouFrom = async (message: Message) => {
       message.content
     );
 
-    if (await multipleCountries(message.content)) {
+    if (matchedCountries.length > 1) {
       await message.reply(
         "Please only tell me 1 country for now, you can ask a member of the Support team about multiple nationalities :grin:"
       );

--- a/src/programs/where-are-you-from.ts
+++ b/src/programs/where-are-you-from.ts
@@ -20,6 +20,11 @@ const whereAreYouFrom = async (message: Message) => {
       message.content
     );
 
+    if (matchedCountries.length === 0) {
+      await message.reply("You must send the flag of the country you are in!");
+      return;
+    }
+
     if (matchedCountries.length > 1) {
       await message.reply(
         "Please only tell me 1 country for now, you can ask a member of the Support team about multiple nationalities :grin:"

--- a/src/programs/where-are-you-from.ts
+++ b/src/programs/where-are-you-from.ts
@@ -15,12 +15,12 @@ const regionCountries = ["USA"];
 const whereAreYouFrom = async (message: Message) => {
   const newUser = !isRegistered(message.member);
 
-  if (newUser) {
+  if (newUser && !message.author.bot) {
     const matchedCountries = CountryRoleFinder.getCountriesFromString(
       message.content
     );
 
-    if (matchedCountries.length > 1) {
+    if (await multipleCountries(message.content)) {
       await message.reply(
         "Please only tell me 1 country for now, you can ask a member of the Support team about multiple nationalities :grin:"
       );
@@ -153,5 +153,13 @@ export const updateAfterRegionSelect = async (
     }
   }
 };
+
+const multipleCountries = async (message: string): Promise<boolean> => {
+  const seperatedEmojis = message.match(/\p{Emoji_Presentation}/gu)
+  if (seperatedEmojis[0] + seperatedEmojis[1] !== seperatedEmojis[2] + seperatedEmojis[3] && seperatedEmojis.length > 2) {
+    return true
+  }
+  return false
+}
 
 export default whereAreYouFrom;

--- a/src/programs/where-are-you-from.ts
+++ b/src/programs/where-are-you-from.ts
@@ -155,11 +155,15 @@ export const updateAfterRegionSelect = async (
 };
 
 const multipleCountries = async (message: string): Promise<boolean> => {
-  const seperatedEmojis = message.match(/\p{Emoji_Presentation}/gu)
-  if (seperatedEmojis[0] + seperatedEmojis[1] !== seperatedEmojis[2] + seperatedEmojis[3] && seperatedEmojis.length > 2) {
-    return true
+  const seperatedEmojis = message.match(/\p{Emoji_Presentation}/gu);
+  if (
+    seperatedEmojis[0] + seperatedEmojis[1] !==
+      seperatedEmojis[2] + seperatedEmojis[3] &&
+    seperatedEmojis.length > 2
+  ) {
+    return true;
   }
-  return false
-}
+  return false;
+};
 
 export default whereAreYouFrom;

--- a/src/utils/country-role-finder.ts
+++ b/src/utils/country-role-finder.ts
@@ -31,23 +31,17 @@ export class CountryRoleFinder {
   }
 
   static getCountriesFromString = (input: string) => {
-    const seperatedEmojis = input.match(/\p{Emoji_Presentation}/gu);
-    const flagEmojis: string[] = [];
+    const flagEmojiRegex = /[\u{1f1e6}-\u{1f1ff}]{2}/gmu;
+    const flagsInInput = input.match(flagEmojiRegex) ?? [];
 
-    if (seperatedEmojis && seperatedEmojis.length > 1) {
-      while (seperatedEmojis.length > 0) {
-        flagEmojis.push(seperatedEmojis[0] + seperatedEmojis[1]);
-        seperatedEmojis.splice(0, 2);
-      }
-    }
-    if (seperatedEmojis && seperatedEmojis.length === 1) {
-      flagEmojis.push(input);
-    }
     const matchedCountries = countries
       .filter((country: Country) => {
+        const isEmojiInInput = country.emoji.match(flagEmojiRegex)
+          ? flagsInInput.includes(country.emoji)
+          : input.includes(country.emoji);
+
         return (
-          flagEmojis.includes(country.emoji) ||
-          input.match(RegExp(`\\b${country.name}\\b`, "i"))
+          isEmojiInInput || input.match(RegExp(`\\b${country.name}\\b`, "i"))
         );
       })
       .map((c) => CountryRoleFinder.emojiToCountryOverrides[c.emoji] ?? c);

--- a/src/utils/country-role-finder.ts
+++ b/src/utils/country-role-finder.ts
@@ -33,24 +33,25 @@ export class CountryRoleFinder {
   static getCountriesFromString = (input: string) => {
     const seperatedEmojis = input.match(/\p{Emoji_Presentation}/gu);
     const flagEmojis: string[] = [];
-    
+
     if (seperatedEmojis && seperatedEmojis.length > 1) {
-    while (seperatedEmojis.length > 0) {
-      flagEmojis.push(seperatedEmojis[0] + seperatedEmojis[1]);
-      seperatedEmojis.splice(0, 2);
+      while (seperatedEmojis.length > 0) {
+        flagEmojis.push(seperatedEmojis[0] + seperatedEmojis[1]);
+        seperatedEmojis.splice(0, 2);
+      }
     }
-  };
     if (seperatedEmojis && seperatedEmojis.length === 1) {
-      flagEmojis.push(input)
-    };
+      flagEmojis.push(input);
+    }
     const matchedCountries = countries
       .filter((country: Country) => {
         return (
           flagEmojis.includes(country.emoji) ||
-          input.match(RegExp(`\\b${country.name}\\b`, "i"))); 
+          input.match(RegExp(`\\b${country.name}\\b`, "i"))
+        );
       })
       .map((c) => CountryRoleFinder.emojiToCountryOverrides[c.emoji] ?? c);
-      return matchedCountries.filter(
+    return matchedCountries.filter(
       ({ name: filterName }, index, self) =>
         self.findIndex(({ name }) => name === filterName) === index
     );

--- a/src/utils/country-role-finder.ts
+++ b/src/utils/country-role-finder.ts
@@ -31,15 +31,17 @@ export class CountryRoleFinder {
   }
 
   static getCountriesFromString = (input: string) => {
+    const seperatedEmojis = input.match(/\p{Emoji_Presentation}/gu);
+    const flagEmojis: string[] = [];
+    while (seperatedEmojis.length > 0) {
+      flagEmojis.push(seperatedEmojis[0] + seperatedEmojis[1]);
+      seperatedEmojis.splice(0, 2);
+    }
     const matchedCountries = countries
       .filter((country: Country) => {
-        return (
-          input.includes(country.emoji) ||
-          input.match(RegExp(`\\b${country.name}\\b`, "i"))
-        );
+        return flagEmojis.includes(country.emoji);
       })
       .map((c) => CountryRoleFinder.emojiToCountryOverrides[c.emoji] ?? c);
-
     return matchedCountries.filter(
       ({ name: filterName }, index, self) =>
         self.findIndex(({ name }) => name === filterName) === index

--- a/src/utils/country-role-finder.ts
+++ b/src/utils/country-role-finder.ts
@@ -33,16 +33,24 @@ export class CountryRoleFinder {
   static getCountriesFromString = (input: string) => {
     const seperatedEmojis = input.match(/\p{Emoji_Presentation}/gu);
     const flagEmojis: string[] = [];
+    
+    if (seperatedEmojis && seperatedEmojis.length > 1) {
     while (seperatedEmojis.length > 0) {
       flagEmojis.push(seperatedEmojis[0] + seperatedEmojis[1]);
       seperatedEmojis.splice(0, 2);
     }
+  };
+    if (seperatedEmojis && seperatedEmojis.length === 1) {
+      flagEmojis.push(input)
+    };
     const matchedCountries = countries
       .filter((country: Country) => {
-        return flagEmojis.includes(country.emoji);
+        return (
+          flagEmojis.includes(country.emoji) ||
+          input.match(RegExp(`\\b${country.name}\\b`, "i"))); 
       })
       .map((c) => CountryRoleFinder.emojiToCountryOverrides[c.emoji] ?? c);
-    return matchedCountries.filter(
+      return matchedCountries.filter(
       ({ name: filterName }, index, self) =>
         self.findIndex(({ name }) => name === filterName) === index
     );


### PR DESCRIPTION
This should close #382, the way emojis are on discord is combining multiple emojis together (does this even make sense..?). The current regex splits them up separately, combines the first 2 indexes and the last 2 in the array, which together will give the first 2 flags send. If they are different, the bot replies with the message. This kind of can be bypassed by sending the same flag twice then a different one but either way he will still get assigned the role of the first flag detected, but the bug was mostly having the same flag twice and it gets detected as different, so that doesn't really matter. 