### PR TITLE
chore: update contributing to mention db migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,13 @@ yarn install
 
 3. Create an `.env` in the root directory and copy the `.env.example`. Change the values to match your test server.
 
-4. Start the bot
+4. Set up the tables in the database
+
+```bash
+yarn prisma db push
+```
+
+5. Start the bot
 
 ```bash
 yarn run start

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ will need the code on your computer, so:
 
 1. [Fork](https://github.com/Yes-Theory-Fam/yesbot-ts/fork) the repository to your user
 
-2. Clone the repo and install the dependencies:
+2. Clone the repo and change the directory to the project for all future commands:
 
 ```bash
 git clone https://github.com/your-username/yesbot-ts.git


### PR DESCRIPTION
The setup guide for YesBot didn't mention migrating or pushing the schema to the DB yet.

This PR includes an additional step in the contributing guide to mention that required command. It also fixes a small left-over phrase that wasn't accurate anymore.