### PR TITLE
fix: require only one role in requiredRoles

### DIFF
--- a/__tests__/event-distribution/events/__snapshots__/message.spec.ts.snap
+++ b/__tests__/event-distribution/events/__snapshots__/message.spec.ts.snap
@@ -39,14 +39,14 @@ Object {
       Object {
         "ioc": Object {},
         "options": Object {
+          "allowedRoles": Array [
+            "Support",
+          ],
           "channelNames": Array [
             "bot-output",
           ],
           "description": "test",
           "event": "MESSAGE",
-          "requiredRoles": Array [
-            "Support",
-          ],
           "trigger": "!test",
         },
       },
@@ -63,15 +63,15 @@ Object {
       Object {
         "ioc": Object {},
         "options": Object {
+          "allowedRoles": Array [
+            "Developer",
+          ],
           "channelNames": Array [
             "bot-development",
             "bot-test-channel",
           ],
           "description": "test",
           "event": "MESSAGE",
-          "requiredRoles": Array [
-            "Developer",
-          ],
           "trigger": "!otherTrigger",
         },
       },
@@ -93,14 +93,14 @@ Object {
       Object {
         "ioc": Object {},
         "options": Object {
+          "allowedRoles": Array [
+            "Support",
+          ],
           "channelNames": Array [
             "bot-output",
           ],
           "description": "test",
           "event": "MESSAGE",
-          "requiredRoles": Array [
-            "Support",
-          ],
           "trigger": "!test",
         },
       },
@@ -111,15 +111,15 @@ Object {
       Object {
         "ioc": Object {},
         "options": Object {
+          "allowedRoles": Array [
+            "Developer",
+          ],
           "channelNames": Array [
             "bot-development",
             "bot-test-channel",
           ],
           "description": "test",
           "event": "MESSAGE",
-          "requiredRoles": Array [
-            "Developer",
-          ],
           "trigger": "!otherTrigger",
         },
       },

--- a/__tests__/event-distribution/events/__snapshots__/reactions.spec.ts.snap
+++ b/__tests__/event-distribution/events/__snapshots__/reactions.spec.ts.snap
@@ -39,15 +39,15 @@ Object {
       Object {
         "ioc": Object {},
         "options": Object {
+          "allowedRoles": Array [
+            "Support",
+          ],
           "channelNames": Array [
             "bot-output",
           ],
           "description": "test",
           "emoji": "♥️",
           "event": "REACTION_REMOVE",
-          "requiredRoles": Array [
-            "Support",
-          ],
         },
       },
     ],
@@ -63,6 +63,9 @@ Object {
       Object {
         "ioc": Object {},
         "options": Object {
+          "allowedRoles": Array [
+            "Developer",
+          ],
           "channelNames": Array [
             "bot-development",
             "bot-test-channel",
@@ -70,9 +73,6 @@ Object {
           "description": "test",
           "emoji": "😘️",
           "event": "REACTION_ADD",
-          "requiredRoles": Array [
-            "Developer",
-          ],
         },
       },
     ],
@@ -93,15 +93,15 @@ Object {
       Object {
         "ioc": Object {},
         "options": Object {
+          "allowedRoles": Array [
+            "Support",
+          ],
           "channelNames": Array [
             "bot-output",
           ],
           "description": "test",
           "emoji": "♥️",
           "event": "REACTION_REMOVE",
-          "requiredRoles": Array [
-            "Support",
-          ],
         },
       },
     ],
@@ -111,6 +111,9 @@ Object {
       Object {
         "ioc": Object {},
         "options": Object {
+          "allowedRoles": Array [
+            "Developer",
+          ],
           "channelNames": Array [
             "bot-development",
             "bot-test-channel",
@@ -118,9 +121,6 @@ Object {
           "description": "test",
           "emoji": "😘️",
           "event": "REACTION_ADD",
-          "requiredRoles": Array [
-            "Developer",
-          ],
         },
       },
     ],

--- a/__tests__/event-distribution/events/message.spec.ts
+++ b/__tests__/event-distribution/events/message.spec.ts
@@ -44,14 +44,14 @@ describe("Messages", () => {
     addMessageHandler(options, ioc, tree);
     expect(tree).toMatchSnapshot();
 
-    const secondOptions = { ...options, requiredRoles: ["Support"] };
+    const secondOptions = { ...options, allowedRoles: ["Support"] };
     addMessageHandler(secondOptions, ioc, tree);
     expect(tree).toMatchSnapshot();
 
     const thirdOptions = {
       ...options,
       trigger: "!otherTrigger",
-      requiredRoles: ["Developer"],
+      allowedRoles: ["Developer"],
       channelNames: ["bot-development", "bot-test-channel"],
     };
     addMessageHandler(thirdOptions, ioc, tree);

--- a/__tests__/event-distribution/events/reactions.spec.ts
+++ b/__tests__/event-distribution/events/reactions.spec.ts
@@ -51,7 +51,7 @@ describe("Reactions", () => {
     const secondOptions: ReactionEventHandlerOptions = {
       ...options,
       event: DiscordEvent.REACTION_REMOVE,
-      requiredRoles: ["Support"],
+      allowedRoles: ["Support"],
     };
     addReactionHandler(secondOptions, ioc, tree);
     expect(tree).toMatchSnapshot();
@@ -59,7 +59,7 @@ describe("Reactions", () => {
     const thirdOptions: ReactionEventHandlerOptions = {
       ...options,
       emoji: "😘️",
-      requiredRoles: ["Developer"],
+      allowedRoles: ["Developer"],
       channelNames: ["bot-development", "bot-test-channel"],
     };
     addReactionHandler(thirdOptions, ioc, tree);

--- a/src/event-distribution/README.md
+++ b/src/event-distribution/README.md
@@ -30,9 +30,9 @@ interface BaseOptions {
   event: DiscordEvent; // Indicates the relevant event
   stateful?: boolean; // If false (default), a new instance of the handler class is created for each event, otherwise an instance is available as singleton for the lifetime of the bot 
   description: string; // A descriptive string of the event handler
-  requiredRoles?: string[]; // An array of role names. All roles listed are required to run the handler.
+  allowedRoles?: string[]; // An array of role names. At least one role listed is required to run the handler.
   channelNames?: string[]; // An array of channel names. The handler will only be called when the event occured in one of the channels listed.
-  location?: EventLocation; // A location enum setting where events are accepted. The default is EventLocation.SERVER if channelNames or requiredRoles is non-empty, EventLocation.ANYWHERE otherwise.
+  location?: EventLocation; // A location enum setting where events are accepted. The default is EventLocation.SERVER if channelNames or allowedRoles is non-empty, EventLocation.ANYWHERE otherwise.
 }
 ```
 

--- a/src/event-distribution/command-decorator.ts
+++ b/src/event-distribution/command-decorator.ts
@@ -49,7 +49,7 @@ export const Command = <T extends EventHandlerOptions>(options: T) => {
 
 const baseOptionsRequireServer = (options: BaseOptions) => {
   const channels = options.channelNames ?? [];
-  const roles = options.requiredRoles ?? [];
+  const roles = options.allowedRoles ?? [];
   return channels.length > 0 || roles.length > 0;
 };
 
@@ -58,7 +58,7 @@ const setDefaultOnBaseOptions = (options: BaseOptions) => {
     ? EventLocation.SERVER
     : EventLocation.ANYWHERE;
 
-  options.requiredRoles ??= [];
+  options.allowedRoles ??= [];
 };
 
 const checkBaseOptions = (options: BaseOptions, commandClassName: string) => {

--- a/src/event-distribution/event-distribution.ts
+++ b/src/event-distribution/event-distribution.ts
@@ -144,7 +144,7 @@ export class EventDistribution {
         return true;
 
       const { requiredRoles } = eh.options;
-      return requiredRoles.every((role) => roleNames.includes(role));
+      return requiredRoles.some((role) => roleNames.includes(role));
     });
   }
 

--- a/src/event-distribution/event-distribution.ts
+++ b/src/event-distribution/event-distribution.ts
@@ -143,8 +143,8 @@ export class EventDistribution {
       )
         return true;
 
-      const { requiredRoles } = eh.options;
-      return requiredRoles.some((role) => roleNames.includes(role));
+      const { allowedRoles } = eh.options;
+      return allowedRoles.some((role) => roleNames.includes(role));
     });
   }
 

--- a/src/event-distribution/types/base.ts
+++ b/src/event-distribution/types/base.ts
@@ -25,7 +25,7 @@ export interface BaseOptions {
   event: DiscordEvent;
   stateful?: boolean;
   description: string;
-  requiredRoles?: string[];
+  allowedRoles?: string[];
   channelNames?: string[];
   location?: EventLocation;
 }

--- a/src/programs/decorator-test.ts
+++ b/src/programs/decorator-test.ts
@@ -39,7 +39,7 @@ export class DecoratorTest extends CommandHandler<DiscordEvent.MESSAGE> {
   stateful: true,
   channelNames: ["bot-output"],
   location: EventLocation.ANYWHERE,
-  requiredRoles: ["Support"],
+  allowedRoles: ["Support"],
 })
 export class DecoratorTest2 extends CommandHandler<DiscordEvent.MESSAGE> {
   called: number = 0;

--- a/src/programs/polls.ts
+++ b/src/programs/polls.ts
@@ -119,7 +119,7 @@ class Polls implements CommandHandler<DiscordEvent.MESSAGE> {
 @Command({
   event: DiscordEvent.REACTION_ADD,
   channelNames: ["polls"],
-  requiredRoles: ["Support"],
+  allowedRoles: ["Support"],
   emoji: "",
   description:
     "This handler mirrors a Support member's new reaction on a poll.",

--- a/src/programs/timeout-timer.ts
+++ b/src/programs/timeout-timer.ts
@@ -14,7 +14,7 @@ interface TimeoutTimerData {
 
 @Command({
   event: DiscordEvent.MESSAGE,
-  requiredRoles: ["Support"],
+  allowedRoles: ["Support"],
   trigger: "!timeoutTimer",
   description: "This handler starts the timeout timer for the timedout user",
 })


### PR DESCRIPTION
Requiring all roles in the requiredRoles array to be present was a bad idea; requiring only one makes so much more sense in our usecases.

This PR renames requiredRoles to allowedRoles and fixes the issue described above.