### PR TITLE
fix: allowed-roles

### DIFF
--- a/src/event-distribution/event-distribution.ts
+++ b/src/event-distribution/event-distribution.ts
@@ -144,7 +144,10 @@ export class EventDistribution {
         return true;
 
       const { allowedRoles } = eh.options;
-      return allowedRoles.some((role) => roleNames.includes(role));
+      return (
+        allowedRoles.length === 0 ||
+        allowedRoles.some((role) => roleNames.includes(role))
+      );
     });
   }
 


### PR DESCRIPTION
Array.some returns false if the array is of zero length. In our usecase an empty array should indicate that everyone may use it, however. This PR fixes the behaviour of allowedRoles.
