### PR TITLE
fix: downgrade countries-and-timezones

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@yes-theory-fam/database": "0.13.0",
     "axios": "0.21.1",
-    "countries-and-timezones": "3.2.1",
+    "countries-and-timezones": "3.1.0",
     "country-code-emoji": "2.3.0",
     "date-fns": "2.23.0",
     "date-fns-tz": "1.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1464,10 +1464,10 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-countries-and-timezones@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/countries-and-timezones/-/countries-and-timezones-3.2.1.tgz#5be0bbb3a4c27ae01ed4dafba68337769acce490"
-  integrity sha512-ksg02vvHTEo+feCcBVFN7zAe+8EO7yfIJhLhwM9O3JsVMaxEYo+LrikxaiQnqSTbKgRwJlRZ8mYrpvAKQE0rsQ==
+countries-and-timezones@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/countries-and-timezones/-/countries-and-timezones-3.1.0.tgz#94865b19810e3bf720bf352fc9b192ffcdea34b6"
+  integrity sha512-Y7iF+Vz1rmTVRbbmvslYn7rnvu5pq8M/7+Z6tXuB4xQod4GA6k1qhbIPAIR/t4uZjgTpfOLX1/p/Q93nyi/mug==
 
 country-code-emoji@2.3.0:
   version "2.3.0"


### PR DESCRIPTION
countries-and-timezones@3.2.x breaks TypeScript compilation.

This PR downgrades the dependency to 3.1.0 to make the build work.