### PR TITLE
Fix: Added DB cleanup and disconnect users who are timed out

### DIFF
--- a/src/programs/timeout-evasion.ts
+++ b/src/programs/timeout-evasion.ts
@@ -110,10 +110,10 @@ class ReportUserOnJoin implements CommandHandler<DiscordEvent.MEMBER_JOIN> {
 })
 class ClearDBOnStart implements CommandHandler<DiscordEvent.READY> {
   async handle(bot: Client): Promise<void> {
-    const TimedOutUsersId = await prisma.timedOutUsers.findMany();
+    const timedOutUsersId = await prisma.timedOutUsers.findMany();
     const guild = bot.guilds.resolve(process.env.GUILD_ID);
-    for (let i = 0; i < TimedOutUsersId.length; i++) {
-      const { userId } = TimedOutUsersId[i];
+    for (let i = 0; i < timedOutUsersId.length; i++) {
+      const { userId } = timedOutUsersId[i];
       const user = guild.members.resolve(userId);
 
       if (!hasRole(user, "Time Out")) {

--- a/src/programs/timeout-evasion.ts
+++ b/src/programs/timeout-evasion.ts
@@ -111,13 +111,13 @@ class ReportUserOnJoin implements CommandHandler<DiscordEvent.MEMBER_JOIN> {
 class ClearDBOnStart implements CommandHandler<DiscordEvent.READY> {
   async handle(bot: Client): Promise<void> {
     const TimedOutUsersId = await prisma.timedOutUsers.findMany();
-    const guild = bot.guilds.resolve(process.env.GUILD_ID)
+    const guild = bot.guilds.resolve(process.env.GUILD_ID);
     for (let i = 0; i < TimedOutUsersId.length; i++) {
-      const { userId } = TimedOutUsersId[i]
-      const user = guild.members.resolve(userId)
+      const { userId } = TimedOutUsersId[i];
+      const user = guild.members.resolve(userId);
 
       if (!hasRole(user, "Time Out")) {
-        await prisma.timedOutUsers.delete({where: {userId: user.id}})
+        await prisma.timedOutUsers.delete({ where: { userId: user.id } });
       }
     }
   }


### PR DESCRIPTION
In case the bot was down and a user was forgiven this should clean it up on ready, so they dont get the the role assigned to them when they rejoin the server.
!closes #474 