### PR TITLE
fix: build action naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  lint:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The build action showed up as Linting with a job "lint" and a step "install and lint" which was incorrect.

This PR corrects the naming of both the action itself as well as both the job and step. It also adds the `--noEmit` flag to disable output files which are not needed for just typechecking which should be a little faster.