### PR TITLE
fix: someone online tag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ const bot = new Client({
     "GUILDS",
     "GUILD_MEMBERS",
     "GUILD_BANS",
+    "GUILD_PRESENCES",
     "GUILD_VOICE_STATES",
     "GUILD_MESSAGES",
     "GUILD_MESSAGE_REACTIONS",

--- a/src/programs/someone-tag.ts
+++ b/src/programs/someone-tag.ts
@@ -114,7 +114,7 @@ async function getTarget(arg: string, message: Message): Promise<User> {
 
   const targetCollection =
     arg && arg === "online"
-      ? sdRole.members.filter((member) => member.presence.status === "online")
+      ? sdRole.members.filter((member) => member.presence?.status === "online")
       : sdRole.members;
 
   if (


### PR DESCRIPTION
This PR fixes `@someone online` by both:

- Adding the `GUILD_PRESENCES` intent to be allowed to fetch presence data in the first place
- Adding an important `?` to the filter for online members; offline members seem to be null now instead of having a status of "offline".