### PR TITLE
Added catch block to memberLeave, guildMemberUpdate, messageManager, …

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ bot.on("ready", async () => {
   await distribution.handleEvent(DiscordEvent.READY, bot);
   LoadCron.init();
   await ready(bot).catch((error) =>
-    logger.error("Error in legacy messageManager handler: ", error)
+    logger.error("Error in legacy ready handler: ", error)
   );
 });
 bot.on(


### PR DESCRIPTION
Added A catch block to memberLeave, guildMemberUpdate, messageManager, ready, voiceStateUpdate

MemberLeave could have been left out since it uses Try Catch but added top-level error catch for legacy handlers