### PR TITLE
Fix: avoid crashing bot on incorrect nickname format

### DIFF
--- a/src/programs/dm-menu.ts
+++ b/src/programs/dm-menu.ts
@@ -75,7 +75,7 @@ class ShowMenu implements CommandHandler<DiscordEvent.MESSAGE> {
       }
 
       const requestedName = nameMessage.first().content;
-      proposeNameChange(requestedName, message);
+      await proposeNameChange(requestedName, message);
       await requestMessage.delete();
     } catch (err) {
       removeIgnore(dmChannel);
@@ -111,7 +111,13 @@ const proposeNameChange = async (name: string, botMessage: Message) => {
         switch (reaction.emoji.toString()) {
           case "✅":
             const member = getMember(botMessage.author.id);
-            member.setNickname(name);
+            member
+              .setNickname(name)
+              .catch((error) =>
+                textLog(
+                  `Could not rename ${botMessage.author.toString()} due to this error: ${error}`
+                )
+              );
             sentMessage.delete();
             textLog(`${botMessage.author.toString()} was renamed to ${name}.`);
             break;


### PR DESCRIPTION
Added an await and threw the error to the bot-output so moderators see the reason why it was denied