### PR TITLE
Feat: Use handleUserError for event user errors

### DIFF
--- a/src/event-distribution/events/events.ts
+++ b/src/event-distribution/events/events.ts
@@ -213,7 +213,7 @@ export const extractEventInfo: ExtractInfoFunction<DiscordEvent> = (
   return Array.isArray(infos) ? infos : [infos];
 };
 
-export const rejectWithMessage = (
+export const rejectWithMessage = async (
   message: string,
   event: DiscordEvent,
   ...args: Parameters<HandlerFunction<DiscordEvent>>
@@ -225,7 +225,7 @@ export const rejectWithMessage = (
         message,
         messageArg.guild
       );
-      return messageArg.reply(channelResolvedMessage);
+      return await Tools.handleUserError(messageArg, channelResolvedMessage);
     default:
       logger.error(
         `Tried to reject event ${event} with message: ${message} but rejection isn't implemented for this event.`


### PR DESCRIPTION
Took longer than expected sorry, anyways `refuseWithMessage` was already awaited when called, so I'm assuming you forgot to add `async` to it, should work as intended.

!closes #590 