### PR TITLE
fix: discord.js test typescript

### DIFF
--- a/__tests__/event-distribution/events/__snapshots__/member-leave.spec.ts.snap
+++ b/__tests__/event-distribution/events/__snapshots__/member-leave.spec.ts.snap
@@ -20,7 +20,10 @@ Object {
   ],
   "isDirectMessage": false,
   "member": Object {
+    "avatar": null,
+    "avatarURL": null,
     "deleted": false,
+    "displayAvatarURL": "https://cdn.discordapp.com/avatars/222222222222222200/user avatar url.webp",
     "displayName": "nick",
     "guildId": "guild-id",
     "joinedTimestamp": NaN,

--- a/__tests__/event-distribution/events/__snapshots__/message.spec.ts.snap
+++ b/__tests__/event-distribution/events/__snapshots__/message.spec.ts.snap
@@ -149,7 +149,10 @@ Array [
     ],
     "isDirectMessage": true,
     "member": Object {
+      "avatar": null,
+      "avatarURL": null,
       "deleted": false,
+      "displayAvatarURL": "https://cdn.discordapp.com/avatars/222222222222222200/user avatar url.webp",
       "displayName": "nick",
       "guildId": "guild-id",
       "joinedTimestamp": NaN,
@@ -172,7 +175,10 @@ Array [
     ],
     "isDirectMessage": false,
     "member": Object {
+      "avatar": null,
+      "avatarURL": null,
       "deleted": false,
+      "displayAvatarURL": "https://cdn.discordapp.com/avatars/222222222222222200/user avatar url.webp",
       "displayName": "nick",
       "guildId": "guild-id",
       "joinedTimestamp": NaN,

--- a/__tests__/event-distribution/events/__snapshots__/reactions.spec.ts.snap
+++ b/__tests__/event-distribution/events/__snapshots__/reactions.spec.ts.snap
@@ -144,7 +144,10 @@ Array [
     ],
     "isDirectMessage": false,
     "member": Object {
+      "avatar": null,
+      "avatarURL": null,
       "deleted": false,
+      "displayAvatarURL": "https://cdn.discordapp.com/avatars/222222222222222200/user avatar url.webp",
       "displayName": "nick",
       "guildId": "guild-id",
       "joinedTimestamp": NaN,

--- a/__tests__/mocks/guild.ts
+++ b/__tests__/mocks/guild.ts
@@ -1,6 +1,7 @@
 import { Client, Guild, GuildMember, Snowflake } from "discord.js";
 import { RawGuildData } from "discord.js/typings/rawDataTypes";
 
+// @ts-expect-error: https://github.com/discordjs/discord.js/issues/6798
 export class MockGuild extends Guild {
   _members: GuildMember[] = [];
 

--- a/__tests__/mocks/guildmember.ts
+++ b/__tests__/mocks/guildmember.ts
@@ -1,6 +1,7 @@
 import { Client, Collection, Guild, GuildMember } from "discord.js";
 import { RawGuildMemberData } from "discord.js/typings/rawDataTypes";
 
+// @ts-expect-error: https://github.com/discordjs/discord.js/issues/6798
 export class MockGuildMember extends GuildMember {
   constructor(client: Client, data: RawGuildMemberData, guild: Guild) {
     super(client, data, guild);

--- a/__tests__/mocks/index.ts
+++ b/__tests__/mocks/index.ts
@@ -137,6 +137,7 @@ export default class MockDiscord {
   }
 
   private mockChannel(): void {
+    // @ts-expect-error: https://github.com/discordjs/discord.js/issues/6798
     this.channel = new Channel(this.client, {
       id: "channel-id",
       name: "Frank",
@@ -145,6 +146,7 @@ export default class MockDiscord {
   }
 
   private mockGuildChannel(): void {
+    // @ts-expect-error: https://github.com/discordjs/discord.js/issues/6798
     this.guildChannel = new GuildChannel(this.guild, {
       ...this.channel,
 
@@ -157,6 +159,7 @@ export default class MockDiscord {
   }
 
   private mockTextChannel(): void {
+    // @ts-expect-error: https://github.com/discordjs/discord.js/issues/6798
     this.textChannel = new TextChannel(this.guild, {
       ...this.guildChannel,
 
@@ -170,6 +173,7 @@ export default class MockDiscord {
   }
 
   private mockUser(): void {
+    // @ts-expect-error: https://github.com/discordjs/discord.js/issues/6798
     this.user = new User(this.client, {
       id: "222222222222222200",
       username: "user username",
@@ -252,6 +256,7 @@ export default class MockDiscord {
   }
 
   private mockRole() {
+    // @ts-expect-error: https://github.com/discordjs/discord.js/issues/6798
     this.role = new Role(
       this.client,
       {
@@ -269,6 +274,7 @@ export default class MockDiscord {
   }
 
   private mockVoiceState() {
+    // @ts-expect-error: https://github.com/discordjs/discord.js/issues/6798
     this.voiceState = new VoiceState(this.guild, {
       deaf: false,
       mute: false,

--- a/__tests__/mocks/message.ts
+++ b/__tests__/mocks/message.ts
@@ -1,6 +1,7 @@
 import { Client, GuildMember, Message, TextBasedChannels } from "discord.js";
 import { RawMessageData } from "discord.js/typings/rawDataTypes";
 
+// @ts-expect-error: https://github.com/discordjs/discord.js/issues/6798
 export class MockMessage extends Message {
   constructor(
     channel: TextBasedChannels,

--- a/__tests__/mocks/reaction.ts
+++ b/__tests__/mocks/reaction.ts
@@ -1,6 +1,7 @@
 import { Client, GuildMember, Message, MessageReaction } from "discord.js";
 import { RawMessageReactionData } from "discord.js/typings/rawDataTypes";
 
+// @ts-expect-error: https://github.com/discordjs/discord.js/issues/6798
 export class MockMessageReaction extends MessageReaction {
   constructor(
     member: GuildMember,


### PR DESCRIPTION
discord.js 13.2.0 included a commit that marked all discord.js classes' constructor private. There is an existing issue talking about this although it was closed by its author here: https://github.com/discordjs/discord.js/issues/6798

Since we depend on those constructors for our mocks/test fixtures, I marked all their use with `@ts-expect-error` so we can start updating discord.js again. Doesn't make me happy to do it this way but I don't see any other approach, honestly.

### Notes

1) This branch merges into the renovate update branch! When merging this, please also merge #533 along with it (only when the pipeline goes green of course!).

2) Since this doesn't merge into master, there are no Actions running on this; I ran this locally and it worked but double checking would be good.