### PR TITLE
fix: canada timezones being empty

### DIFF
--- a/src/programs/birthday-manager.ts
+++ b/src/programs/birthday-manager.ts
@@ -411,9 +411,7 @@ function timezonesFromRole(props: CountryWithRegion): readonly string[] {
     case "UK":
       return getCountry("GB").timezones;
     case "Mexico":
-      return getCountry("MX")
-        .timezones // BajaSur and BajaNorth are invalid in JS.
-        .filter((tz) => !tz.startsWith("Mexico/Baja"));
+      return getCountry("MX").timezones;
     case "Australia": {
       return [
         "Australia/Perth",
@@ -424,7 +422,7 @@ function timezonesFromRole(props: CountryWithRegion): readonly string[] {
       ];
     }
     case "Canada": {
-      return getCountry("CA").timezones.filter((tz) =>
+      return getCountry("CA", {deprecated: true}).timezones.filter((tz) =>
         tz.startsWith("Canada/")
       );
     }

--- a/src/programs/birthday-manager.ts
+++ b/src/programs/birthday-manager.ts
@@ -150,7 +150,9 @@ class BirthdayManager implements CommandHandler<DiscordEvent.MESSAGE> {
       } else if (err instanceof Error && err.message === "time expired") {
         await message.react("⏰");
       } else if (err instanceof Error && err.message === "No timezone found") {
-        await message.reply(`Whoops! We couldn't figure out potential timezones for you. Calling for help :telephone: ${engineerRole.toString()}`);
+        await message.reply(
+          `Whoops! We couldn't figure out potential timezones for you. Calling for help :telephone: ${engineerRole.toString()}`
+        );
       } else {
         logger.error(
           "An unknown error has occurred awaiting the users timezone: ",
@@ -429,7 +431,7 @@ function timezonesFromRole(props: CountryWithRegion): readonly string[] {
       ];
     }
     case "Canada": {
-      return getCountry("CA", {deprecated: true}).timezones.filter((tz) =>
+      return getCountry("CA", { deprecated: true }).timezones.filter((tz) =>
         tz.startsWith("Canada/")
       );
     }


### PR DESCRIPTION
A recent update of countries-and-timezones updated the timezone data which deprecated Canada/-prefixed timezones. This PR adds the deprecated option to restore old behaviour.

The bot now further automatically pings Developers in case no timezones were found for a member to not have them wonder what happened and instead push that fate onto the Developers.