### PR TITLE
fix: double group command execution

### DIFF
--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -1,4 +1,4 @@
-import { GuildChannel, Message, TextChannel } from "discord.js";
+import { Message, TextChannel } from "discord.js";
 import {
   ExportManager,
   GroupManager,
@@ -18,7 +18,6 @@ const routeMessage = async (message: Message) => {
   const words = message.content.split(/\s+/);
   const channel = <TextChannel>message.channel;
   const firstWord = words[0];
-  const restOfMessage = words.slice(1).join(" ");
 
   switch (channel.name) {
     case "permanent-testing":

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -28,6 +28,7 @@ const routeMessage = async (message: Message) => {
         !message.content.toLowerCase().startsWith("!group toggle")
       )
         await GroupManager(message, true);
+      break;
     case "bot-commands":
       if (
         firstWord === "!group" &&


### PR DESCRIPTION
Currently a missing `break;` causes !group commands to be executed twice in permanent-testing. This PR reintroduces it.