### PR TITLE
fix: onFailure being called despite undefined

### DIFF
--- a/src/programs/tickets/travel/common.ts
+++ b/src/programs/tickets/travel/common.ts
@@ -238,7 +238,7 @@ async function getString(
   return await retryUntilSatisfied(
     () => _getString(channel, userId, prompt, timeout),
     (s) => Boolean(s?.length),
-    ct,
+    ct
   );
 }
 

--- a/src/programs/tickets/travel/common.ts
+++ b/src/programs/tickets/travel/common.ts
@@ -238,7 +238,7 @@ async function getString(
   return await retryUntilSatisfied(
     () => _getString(channel, userId, prompt, timeout),
     (s) => Boolean(s?.length),
-    ct
+    ct,
   );
 }
 
@@ -358,7 +358,7 @@ const retryUntilSatisfied = async <T>(
       break;
     }
 
-    await onFailure();
+    await onFailure?.();
 
     retryCount -= 1;
     if (!retryCount) {


### PR DESCRIPTION
This fixes an issue with `!travel` causing missing details to kill the travel request entirely without any feedback to the member. 