### PR TITLE
Fix: Voice up and down limits vc to current members +1 

### DIFF
--- a/src/programs/voice-on-demand.ts
+++ b/src/programs/voice-on-demand.ts
@@ -123,10 +123,10 @@ const getShrinkLimit = (channel: VoiceChannel) =>
   Math.max(2, channel.members.size);
 
 const getUpLimit = (channel: VoiceChannel) =>
-  Math.min(maxLimit, channel.userLimit + 1);
+  Math.min(maxLimit, channel.members.size + 1);
 
 const getDownLimit = (channel: VoiceChannel) =>
-  Math.max(2, channel.userLimit - 1);
+  Math.max(2, channel.members.size - 1);
 
 const createOnDemand = async (message: Message, userLimit: number) => {
   const { guild, member } = message;


### PR DESCRIPTION
Some users would `!voice limit 2` in a channel of 5 members in case someone disconnects and to avoid losing his place or getting a random. But this generates a bug where `!voice up` or accepting a `!voice knock` would just up one to the channel limit.

> Channel members: 5
Channel limit: 2
Do a `!voice up`
Expectations: Channel limit: 6
Results: Channel limit: 3