### PR TITLE
Fix: race condition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ bot.on(
 );
 bot.on("ready", async () => {
   await ready(bot).catch((error) =>
-      logger.error("Error in legacy ready handler: ", error)
+    logger.error("Error in legacy ready handler: ", error)
   );
   await distribution.handleEvent(DiscordEvent.READY, bot);
   LoadCron.init();

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,11 +117,11 @@ bot.on(
   }
 );
 bot.on("ready", async () => {
+  await ready(bot).catch((error) =>
+      logger.error("Error in legacy ready handler: ", error)
+  );
   await distribution.handleEvent(DiscordEvent.READY, bot);
   LoadCron.init();
-  await ready(bot).catch((error) =>
-    logger.error("Error in legacy ready handler: ", error)
-  );
 });
 bot.on(
   "voiceStateUpdate",


### PR DESCRIPTION
This could be a possible fix for #736 since we have two `ready.ts` that handle the bot ready event, we can make the old event take resolving the guild before heading to the new event distribution system. I'm assuming that when you said color selection, you meant the nitro colors since they use the new `ready.ts` loading the old one first doesn't seem like a lousy idea 🤔 

Hopefully !closes #736 