### PR TITLE
fix: channels not being found with multiple spaces

### DIFF
--- a/src/programs/tickets/common.ts
+++ b/src/programs/tickets/common.ts
@@ -95,6 +95,7 @@ export const getChannelName = (user: User, ticketType: TicketType) => {
     user.username + user.discriminator
   ).toLowerCase()}`;
   channelName = channelName.replace(/\s+/g, "-").toLowerCase();
+  channelName = channelName.replace(/-+/g, "-");
   return channelName.replace(/[^\dA-Z\s+-]/gi, "");
 };
 


### PR DESCRIPTION
The current code creates channel names with multiple dashes which Discord automatically collapses to a single one causing channels not to be found anymore.