### PR TITLE
fix: `UNKNOWN_ERROR` when a member is not in any group

### DIFF
--- a/src/programs/group-manager/group-service.ts
+++ b/src/programs/group-manager/group-service.ts
@@ -43,8 +43,13 @@ export class GroupService {
 
     await prisma.userGroupMembersGroupMember.create({
       data: {
-        userGroupId: groupId,
-        groupMemberId: userId,
+        userGroup: { connect: { id: groupId } },
+        groupMember: {
+          connectOrCreate: {
+            where: { id: userId },
+            create: { id: userId },
+          },
+        },
       },
     });
   }


### PR DESCRIPTION
- fix: `UNKNOWN_ERROR`  which prevented the user from joining any group if they were not enrolled in at least one group.