### PR TITLE
fix: command check

### DIFF
--- a/src/common/tools.ts
+++ b/src/common/tools.ts
@@ -173,7 +173,14 @@ class Tools {
     const appliedPermissions =
       permissions.get(commandId) ?? permissions.get(guild.client.user.id) ?? [];
 
-    return appliedPermissions.some((p) => p.type === 1 && p.permission);
+    const supportId = this.getRoleByName(
+      process.env.MODERATOR_ROLE_NAME,
+      guild
+    )?.id;
+
+    return appliedPermissions.some(
+      (p) => p.type === 1 && p.permission && p.id !== supportId
+    );
   }
 
   /**


### PR DESCRIPTION
The check to see if a command was enabled was including the Support role, which is default enabled for all commands on the production server.