### PR TITLE
fix: lookup-voice-by-channel

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,10 +136,9 @@ model Valentine {
 
 model VoiceOnDemandMapping {
   userId    String @id @map("user_id") @db.VarChar
-  channelId String @map("channel_id") @db.VarChar
+  channelId String @unique @map("channel_id") @db.VarChar
   emoji     String @db.VarChar
 
-  @@unique([channelId], name: "IDX_VoiceOnDemandMapping_Unique_Channel")
   @@map(name: "voice_on_demand_mapping")
 }
 


### PR DESCRIPTION
Fixes a bug that showed up in sentry by replacing a custom unique constraint with a more direct unique constraint on the field itself