### PR TITLE
fix: prevent crash from circular references in errors

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -14,7 +14,7 @@ const fmt = format.printf(({ level, message, timestamp, ...meta }) => {
 
   // Add a json-kinda dict with metadata if present
   if (Object.keys(fields).length > 0) {
-    return `${out}${level} [${kind}] [${program}]: ${message} ${JSON.stringify(
+    return `${out}${level} [${kind}] [${program}]: ${message} ${inspect(
       fields
     )}`;
   }


### PR DESCRIPTION
`util.inspect` prevents circular dependencies from breaking JSON serialization. The previous implementation caused error logging to crash the bot entirely in case the error contained any circular dependencies as is often the case with HTTP Request / Response objects.