### PR TITLE
fix: uncaught promise crash in !travel

### DIFF
--- a/src/programs/tickets/common.ts
+++ b/src/programs/tickets/common.ts
@@ -84,9 +84,13 @@ const hasTicket = async (message: Message, channelName: string) => {
 
   const dm = await message.author.createDM();
 
-  await dm.send(
-    "You already have a ticket open, please close that one first before opening another."
-  );
+  try {
+    await dm.send(
+      "You already have a ticket open, please close that one first before opening another."
+    );
+  } catch (e) {
+    /* Locked down DMs */
+  }
   return true;
 };
 

--- a/src/programs/tickets/common.ts
+++ b/src/programs/tickets/common.ts
@@ -82,11 +82,11 @@ const hasTicket = async (message: Message, channelName: string) => {
   );
   if (!channel) return false;
 
-  message.author.createDM().then((channel) => {
-    channel.send(
-      "You already have a ticket open, please close that one first before opening another."
-    );
-  });
+  const dm = await message.author.createDM();
+
+  await dm.send(
+    "You already have a ticket open, please close that one first before opening another."
+  );
   return true;
 };
 


### PR DESCRIPTION
If both
- A user already had a ticket open *and*
- They had their DMs locked down

The bot would crash due to a missing `await` and thus uncaught promise rejection.