### PR TITLE
fix: modern travel truncates activities

### DIFF
--- a/src/programs/tickets/travel/travel-data-message-converter.ts
+++ b/src/programs/tickets/travel/travel-data-message-converter.ts
@@ -46,7 +46,7 @@ export class TravelDataMessageConverter {
     const hostMatch = /\*\*Looking for a host\*\*: (Yes|No)/gm.exec(content);
     const needsHost = hostMatch?.at(1) === "Yes";
 
-    const activitiesMatch = /\*\*Activities\*\*:((?:.|\n).*)/gm.exec(content);
+    const activitiesMatch = /\*\*Activities\*\*:((?:.|\n)*)/gm.exec(content);
     const activities = activitiesMatch?.at(1) ?? "";
 
     return {


### PR DESCRIPTION
A mistake in the regex caused the message parser to ignore everything but the first line of the activities. This PR fixes that behaviour.