### PR TITLE
fix: remove bad response

### DIFF
--- a/src/programs/custom-messages.ts
+++ b/src/programs/custom-messages.ts
@@ -47,7 +47,6 @@ const randomReply = async (message: Message) => {
     "flip a coin: Head is yes, Tails is no",
     "never in a million years",
     "claro que si", // yes of course
-    "just do it (not sponsored by nike)",
     "hahahahahhaha... no.",
     "yes, I totally agree",
     "as long as I’m alive.",


### PR DESCRIPTION
Since YesBot is usually asked "Yes / No" questions, this response often didn't make sense (e.g. "Does X love me?" - "Just do it"). Thus it's been removed.