### PR TITLE
fix/travel tickets

### DIFF
--- a/src/programs/tickets/travel/travel-data-message-converter.ts
+++ b/src/programs/tickets/travel/travel-data-message-converter.ts
@@ -24,7 +24,22 @@ export class TravelDataMessageConverter {
   }
 
   static fromMessage(message: Message, guild: Guild): TripDetails {
-    const content = message.content;
+    const boundary = "---\n";
+    const messageContent = message.content;
+    const declinedMessageBoundaryStart = Math.max(
+      messageContent.indexOf(boundary),
+      0
+    );
+    const declinedMessageBoundaryEnd = Math.max(
+      messageContent.lastIndexOf(boundary),
+      0
+    );
+    const content = messageContent
+      .substring(
+        declinedMessageBoundaryStart + boundary.length,
+        declinedMessageBoundaryEnd
+      )
+      .trim();
 
     const countryNameMatch = /Hey (.*)!$/gm.exec(content);
     const countryNames = countryNameMatch?.at(1)?.split(/\s*,\s*/) ?? [];

--- a/src/programs/tickets/travel/travel-data-message-converter.ts
+++ b/src/programs/tickets/travel/travel-data-message-converter.ts
@@ -23,23 +23,25 @@ export class TravelDataMessageConverter {
 **Activities**: ${details.activities}`;
   }
 
-  static fromMessage(message: Message, guild: Guild): TripDetails {
+  private static sanitizeMessageContent(messageContent: string): string {
     const boundary = "---\n";
-    const messageContent = message.content;
-    const declinedMessageBoundaryStart = Math.max(
-      messageContent.indexOf(boundary),
-      0
-    );
-    const declinedMessageBoundaryEnd = Math.max(
-      messageContent.lastIndexOf(boundary),
-      0
-    );
-    const content = messageContent
+    const declinedMessageBoundaryStart = messageContent.indexOf(boundary);
+    const declinedMessageBoundaryEnd = messageContent.lastIndexOf(boundary);
+
+    if (declinedMessageBoundaryStart === -1) return messageContent;
+
+    return messageContent
       .substring(
         declinedMessageBoundaryStart + boundary.length,
-        declinedMessageBoundaryEnd
+        declinedMessageBoundaryEnd === -1
+          ? messageContent.length
+          : declinedMessageBoundaryEnd
       )
       .trim();
+  }
+
+  static fromMessage(message: Message, guild: Guild): TripDetails {
+    const content = this.sanitizeMessageContent(message.content);
 
     const countryNameMatch = /Hey (.*)!$/gm.exec(content);
     const countryNames = countryNameMatch?.at(1)?.split(/\s*,\s*/) ?? [];

--- a/src/programs/tickets/travel/travel-editing.ts
+++ b/src/programs/tickets/travel/travel-editing.ts
@@ -39,7 +39,8 @@ export class TravelEditing {
     details: TripDetails,
     interaction:
       | MessageComponentInteraction
-      | ModalMessageModalSubmitInteraction
+      | ModalMessageModalSubmitInteraction,
+    countriesEnabled = true
   ): Promise<EditResult> {
     const userId = interaction.user.id;
 
@@ -73,7 +74,11 @@ export class TravelEditing {
 
     switch (buttonInteraction.customId) {
       case editId:
-        return await this.doEditing(details, buttonInteraction);
+        return await this.doEditing(
+          details,
+          buttonInteraction,
+          countriesEnabled
+        );
       case doneId:
         return { details, interaction: buttonInteraction };
       default:
@@ -128,7 +133,11 @@ export class TravelEditing {
     const { details: newDetails, interaction: newDetailsInteraction } =
       await this.getNewDetails(details, selectionInteraction);
 
-    return await this.offerEditing(newDetails, newDetailsInteraction);
+    return await this.offerEditing(
+      newDetails,
+      newDetailsInteraction,
+      countriesEnabled
+    );
   }
 
   private async getNewDetails(


### PR DESCRIPTION
This PR fixes three bugs in the new travel command related to editing a declined ticket in DMs:

1. After editing the first time, attempting to edit again allowed editing countries which results in a dead end (because there are no countries available)
2. When editing details, the Activities section was also prefilled with "---\nYou can edit or cancel your ticket"
3. When the ticket was declined with a reason that matched `/Hey (.*)!$/`, parsing countries would fail leading to no countries being pinged
