### PR TITLE
fix: break role

### DIFF
--- a/src/programs/break-role/break-role-added.ts
+++ b/src/programs/break-role/break-role-added.ts
@@ -11,15 +11,21 @@ import {
 } from "discord.js";
 import prisma from "../../prisma";
 import { getRoleAccessedChannels } from "./common";
+import Tools from "../../common/tools";
 
 @Command({
   event: DiscordEvent.GUILD_MEMBER_UPDATE,
   roleNamesAdded: ["Break"],
 })
 class BreakRoleAdded extends CommandHandler<DiscordEvent.GUILD_MEMBER_UPDATE> {
-  async handle(oldMember: GuildMember, newMember: GuildMember): Promise<void> {
+  async handle(_: GuildMember, newMember: GuildMember): Promise<void> {
     await this.revokePerUserPermissions(newMember);
     await this.lockRoleChannels(newMember);
+
+    const memberRole = Tools.getRoleByName("Member", newMember.guild);
+    if (memberRole) {
+      await newMember.roles.remove(memberRole);
+    }
   }
 
   private async revokePerUserPermissions(member: GuildMember) {

--- a/src/programs/break-role/break-role-removed.ts
+++ b/src/programs/break-role/break-role-removed.ts
@@ -16,6 +16,11 @@ class BreakRoleRemoved extends CommandHandler<DiscordEvent.GUILD_MEMBER_UPDATE> 
   async handle(oldMember: GuildMember, newMember: GuildMember): Promise<void> {
     await this.resolvePerUserPermissions(newMember);
     await this.unlockRoleChannels(newMember);
+
+    const memberRole = Tools.getRoleByName("Member", newMember.guild);
+    if (memberRole) {
+      await newMember.roles.add(memberRole);
+    }
   }
 
   private async resolvePerUserPermissions(member: GuildMember) {


### PR DESCRIPTION
Due to permission changes, the Break role (ironically) broke. To fix, we make adding the Break role remove the Member role and removing the Break role re-add the Member role.