### PR TITLE
chore: remove problematic line from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,4 +33,3 @@ YTF_FRONTEND_URL=http://localhost:3000
 YTF_CMS_URL=http://localhost:3001
 YTF_API_AUTH_TOKEN=
 YTF_GRAPHQL_ENDPOINT=http://localhost:5001/graphql
-YTF_GRAPHQL_SCHEMA_ENDPOINT=http://localhost:5002/_yesbot-schema


### PR DESCRIPTION
That line apparently made the setup fail