### PR TITLE
fix: ignore Discord's polls

### DIFF
--- a/src/programs/polls.ts
+++ b/src/programs/polls.ts
@@ -96,7 +96,7 @@ class Polls implements CommandHandler<DiscordEvent.MESSAGE> {
     // Excludes Discord's native polls and results
     if (message.poll || message.system) return;
 
-    const lines = message.cleanContent.split("\n");
+    const lines = message.content.split("\n");
     const resolvedEmojis = resolveEmojis(
       lines.map(removeSpecialCharactersFromBeginning),
       message.client

--- a/src/programs/polls.ts
+++ b/src/programs/polls.ts
@@ -92,9 +92,9 @@ const removeSpecialCharactersFromBeginning = (content: string) => {
 })
 class Polls implements CommandHandler<DiscordEvent.MESSAGE> {
   async handle(message: Message): Promise<void> {
-    if (message.author.bot) {
-      return;
-    }
+    if (message.author.bot) return;
+    // Excludes Discord's native polls and results
+    if (message.poll || message.system) return;
 
     const lines = message.cleanContent.split("\n");
     const resolvedEmojis = resolveEmojis(


### PR DESCRIPTION
- don't react to Discord's native polls
- don't react to poll results (or any other system messages) in polls
- fix the bug where you could not use custom emojis (that are on the server) when creating polls

#1379 